### PR TITLE
Add query parameter to filter rewards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ The following parameters are supported:
 - `order`: whether to order the transactions in ascending or descending order of occurrence. A value beginning with `d` or `D` is interpreted as descending; any other (or no) value is interpreted as ascending.
 - `from`: a transaction id. If the order is ascending, return transactions with higher ids than this; if the order is descending, return transactions with lower ids.
 - `limit`: the maximum number of transactions to return; defaults to 20; values above 1000 are treated as 1000.
+- `includeRewards`: whether to include rewards, and if so, which ones. This is
+  an optional parameter which defaults to including all rewards. The possible
+  values are
+  - `none`: include no rewards, including minting
+  - `allButFinalization`: include all but finalization rewards
+  - `all`: include all rewards. This is also the default if not supplied.
 
 The result is a JSON object with the following fields:
 - `order`: either `"ascending"` or `"descending"` indicating the ordering applied to the transactions.


### PR DESCRIPTION
## Purpose

Add ability to specify which rewards types should be included in the accTransactions response.
This is needed so the wallet does not have to make repeated requests to get this information.

## Changes

Add a query parameter `includeRewards`. See README for details of the meaning.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
