### PR TITLE
Disable sessions and sessions cookies.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Changelog for wallet-proxy
 
 ## Unreleased changes
+
+ - Disable sessions since we don't use them.
+
+## 0.5.0
  - Make the GTU drop functionality optional.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.5.0
+version:             0.6.0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -89,6 +89,8 @@ data GTUDropData = GTUDropData {
   }
 
 instance Yesod Proxy where
+  -- Disable session handling entirely. We do not use sessions for anything at the moment.
+  makeSessionBackend _ = return Nothing
   errorHandler e = do
     case e of
       Yesod.InternalError emsg -> $(logError) emsg


### PR DESCRIPTION
## Purpose

One of the issues pointed out in the audit of the mobile wallet was that the
backend (the wallet-proxy) sends the session cookie even if the connection is
not secure and that this should be disabled. Since we do not use sessions for
anything it is simpler to just disable it entirely.

## Changes

Disable the built-in session handling defaults

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
