### PR TITLE
Include a raw reject reason if so asked.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
  - Disable sessions since we don't use them.
+ - Add query parameter `includeRawRejectReason` to the `accTransactions` query.
 
 ## 0.5.0
  - Make the GTU drop functionality optional.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ The following parameters are supported:
   - `none`: include no rewards, including minting
   - `allButFinalization`: include all but finalization rewards
   - `all`: include all rewards. This is also the default if not supplied.
+- `includeRawRejectReason`: whether to include the raw rejection reason (the
+  same JSON as returned by `GetTransactionStatus` gRPC endpoint).
 
 The result is a JSON object with the following fields:
 - `order`: either `"ascending"` or `"descending"` indicating the ordering applied to the transactions.


### PR DESCRIPTION
## Purpose

Expose the raw rejection JSON so that the desktop wallet so they can connect it to rejection types
returned by `GetTransactionStatus`. The solution is not ideal, but it achieves
what it needs to, without being too cumbersome.

## Changes

Add a query parameter to include additional data.
The reason I am not always including it is to not accidentally break something if there is a user with strict JSON parsing.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.