### PR TITLE
Adding a health request

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
  - Disable sessions since we don't use them.
  - Add query parameter `includeRawRejectReason` to the `accTransactions` query.
+ - health query checks connections to database and GRPC, and that the last final
+   block is less than 5 minutes old.
 
 ## 0.5.0
  - Make the GTU drop functionality optional.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,8 @@
  - Disable sessions since we don't use them.
  - Add query parameter `includeRawRejectReason` to the `accTransactions` query.
  - health query checks connections to database and GRPC, and that the last final
-   block is less than 5 minutes old.
+   block is less than `health-tolerance` seconds old. `health-tolerance` is 300
+   seconds unless an alternative value is chosen at startup.
 
 ## 0.5.0
  - Make the GTU drop functionality optional.

--- a/README.md
+++ b/README.md
@@ -529,7 +529,9 @@ If the account address is well-formed, but the account does not exist in a final
 ## Health
 
 Returns an object specifying if the information accessible from the wallet proxy is up to date.
-It will query the GRPC and the transaction database, assuming both succeeds it checks that the last final block is less than 5 minutes old.
+It will query the GRPC and the transaction database. Assuming both succeeds it checks that the last final block is less than `health-tolerance` seconds old.
+`health-tolerance` is an optional parameter to the wallet-proxy. It defaults to 300 seconds if left unspecified.
+
 Under normal conditions the health query returns:
 ```json
 {
@@ -612,6 +614,7 @@ wallet-proxy --grpc-ip 127.0.0.1\ # IP of the node
              --db "host=localhost port=5432 dbname=transaction-outcome user=postgres password=postgres"\ # transaction outcome database connection string
              --ip-data identity-providers-with-metadata.json\ # JSON file with identity providers and anonymity revokers
              --drop-account gtu-drop-account-0.json # keys of the gtu drop account
+             --health-tolerance 30 # tolerated age of last final block in seconds before the health query returns false
 ```
 
 ## Identity providers metadata file

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The wallet proxy provides the following endpoints:
 * `PUT /v0/submitTransfer`: perform a simple transfer
 * `GET /v0/accTransactions/{accountNumber}`: get the transactions affecting an account
 * `PUT /v0/testnetGTUDrop/{accountNumber}`: request a GTU drop to the specified account
+* `GET /v0/health`: get a response specifying if the wallet proxy is up to date
 * `GET /v0/global`: get the cryptographic parameters obtained from the node it is connected to
 * `GET /v0/ip_info`: get the identity providers information, including links for
   submitting initial identity issuance requests.
@@ -524,6 +525,27 @@ If for some reason the drop fails, subsequent calls could return a new `submissi
 
 If the account address is well-formed, but the account does not exist in a finalized state on the chain, this call fails with a **404 Not found** status code.
 
+
+## Health
+
+Returns an object specifying if the information accessible from the wallet proxy is up to date.
+It will query the GRPC and the transaction database, assuming both succeeds it checks that the last final block is less than 5 minutes old.
+Under normal conditions the health query returns:
+```json
+{
+  "healthy":true,
+  "lastFinalTime":"2021-07-06T11:55:49.5Z"
+}
+```
+If the queries succeeded but the last final block is too old it will return:
+```json
+{
+  "healthy":false,
+  "reason":"The last final block is too old.",
+  "lastFinalTime":"2021-07-06T11:55:49.5Z"
+}
+```
+If one of the queries fail, it could return `healthy=false` with a reason, or an error.
 
 ## Notes on account balances.
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ If the account address is well-formed, but the account does not exist in a final
 ## Health
 
 Returns an object specifying if the information accessible from the wallet proxy is up to date.
-It will query the GRPC and the transaction database. Assuming both succeeds it checks that the last final block is less than `health-tolerance` seconds old.
+It will query the GRPC and the transaction database. Assuming both succeed it checks that the last final block is less than `health-tolerance` seconds old.
 `health-tolerance` is an optional parameter to the wallet-proxy. It defaults to 300 seconds if left unspecified.
 
 Under normal conditions the health query returns:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -76,7 +76,7 @@ main :: IO ()
 main = do
   ProxyConfig{..} <- execParser parser
   let logm s = runStderrLoggingT ($logDebug ("[GRPC]: " <> s))
-  healthTolerance <- return $ fromMaybe 300 pcHealthTolerance -- use 5 minutes as default health tolerance
+  let healthTolerance = fromMaybe 300 pcHealthTolerance -- use 5 minutes as default health tolerance
   gtuDropData <- case pcGTUAccountFile of
     Nothing -> return Nothing
     Just accFile -> do


### PR DESCRIPTION
## Purpose

Adds a health request to the wallet proxy so that a wallet can ping it to check how "up to date" the information displayed is.

## Changes

The request sends a GRPC query for the information on the last final block, and then queries the database for a single row. Then it checks that the slot time of the last final block was no more than 5 minutes ago.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] I have updated the CHANGELOG.
