### PR TITLE
Add support for transaction memos.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,16 @@
 # Changelog for wallet-proxy
 
-## Unreleased changes
+## 0.7.0
+
+ - Add support for transfers with a memo.
+   - New endpoint v1/accTransactions which lists transfers with a memo.
+   - v0/transactionCost endpoint is updated to support new transfer types. The
+     change is backwards compatible.
+   - Existing v0/accTransactions endpoint converts outcomes of new transaction
+     types to old ones.
+   - Minimum supported node version is bumped to 1.2.
+
+## 0.6.0
 
  - Disable sessions since we don't use them.
  - Add query parameter `includeRawRejectReason` to the `accTransactions` query.

--- a/README.md
+++ b/README.md
@@ -188,12 +188,13 @@ In case of success the response will always be a JSON object with required field
   conversion rates
 - `"energy"` which is the energy that is required be supplied for execution of this transaction.
 
-In case of invalid parameters the response will be with the following status codes
+In case of invalid parameters the response will be as described in the [errors section](#errors) with the following possible status codes
 - `400` if any of the following apply
   - the transaction type parameter is missing
   - numSignatures is present but it cannot be parsed as an integer
   - memoSize is present but it cannot be parsed as an integer
 - `404` if `memoSize` is present, but the node that backs the wallet-proxy is still running protocol version 1.
+- `502` if the wallet-proxy cannot access the node.
 
 ## Submission Status
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.6.0
+version:             0.7.0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Internationalization/Base.hs
+++ b/src/Internationalization/Base.hs
@@ -27,6 +27,8 @@ data ErrorMessage
     | EMConfigurationError
     | EMAccountDoesNotExist
     | EMMissingParameter
+    -- |Action not supported due to the node protocol version not allowing it.
+    | EMActionNotCurrentlySupported
 
 data I18n = I18n {
     i18nRejectReason :: RejectReason -> Text,

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -80,6 +80,7 @@ translation = I18n {..}
         i18nTransactionType TTInitContract = "Initialize smart contract"
         i18nTransactionType TTUpdate = "Invoke smart contract"
         i18nTransactionType TTTransfer = "Transfer"
+        i18nTransactionType TTTransferWithMemo = "Transfer with a memo"
         i18nTransactionType TTUpdateBakerStake = "Update baker stake"
         i18nTransactionType TTUpdateBakerKeys = "Update baker keys"
         i18nTransactionType TTUpdateBakerRestakeEarnings = "Update whether to restake baker earnings"
@@ -87,9 +88,11 @@ translation = I18n {..}
         i18nTransactionType TTRemoveBaker = "Remove baker"
         i18nTransactionType TTUpdateCredentialKeys = "Update credential keys"
         i18nTransactionType TTEncryptedAmountTransfer = "Shielded transfer"
+        i18nTransactionType TTEncryptedAmountTransferWithMemo = "Shielded transfer with a memo"
         i18nTransactionType TTTransferToEncrypted = "Shielded amount"
         i18nTransactionType TTTransferToPublic = "Unshielded amount"
         i18nTransactionType TTTransferWithSchedule = "Transfer with schedule"
+        i18nTransactionType TTTransferWithScheduleAndMemo = "Transfer with schedule and a memo"
         i18nTransactionType TTUpdateCredentials = "Update account credentials"
         i18nTransactionType TTRegisterData = "Register data on the chain"
 
@@ -131,6 +134,7 @@ translation = I18n {..}
         i18nEvent TransferredWithSchedule{..} = "Transferred with schedule from " <> descrAccount etwsFrom <> " to " <> descrAccount etwsTo
         i18nEvent CredentialsUpdated{..} = "Credentials on account " <> descrAccount cuAccount <> " updated."
         i18nEvent DataRegistered{} = "Data registered on the chain."
+        i18nEvent TransferMemo{..} = "Memo '" <> Text.pack (show tmMemo) <> "' included in a transfer." -- TODO: This would ideally try to render the Memo in a readable way, if it is a valid string or integer, say.
 
         i18nSpecialEvent BakingRewards{..} = "Baking rewards\n" <>
             Text.unlines (map (\(addr, amnt) -> "  - account " <> descrAccount addr <> " awarded " <> descrAmount amnt) . Map.toAscList . accountAmounts $ stoBakerRewards)
@@ -172,3 +176,4 @@ translation = I18n {..}
         i18nErrorMessage EMConfigurationError = "Server configuration error"
         i18nErrorMessage EMAccountDoesNotExist = "Account does not exist"
         i18nErrorMessage EMMissingParameter = "Missing parameter"
+        i18nErrorMessage EMActionNotCurrentlySupported = "The required action is not supported. The node's protocol version is incompatible with it."

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -791,7 +791,7 @@ formatEntry includeMemos rawRejectReason i self (Entity key Entry{}, Entity _ Su
 
           details = case includeMemos of
             IncludeMemo -> object $ ["type" .= renderTransactionSummaryType tsType, "description" .= i18n i tsType] <> resultDetails
-            ExcludeMemo -> object $ ["type" .= renderTransactionSummaryType (forgetMemoInSummary tsType), "description" .= i18n i (forgetMemoInSummary tsType)] <> resultDetails
+            ExcludeMemo -> object $ ["type" .= renderTransactionSummaryType (forgetMemoInSummary tsType), "description" .= i18n i tsType] <> resultDetails
 
           costs
             | selfOrigin = case subtotal of


### PR DESCRIPTION
## Purpose

Add support for transfers with memo.

- Closes #18
- Closes #19 

## Changes

- New endpoint v1/accTransactions which lists transfers with a memo.
- v0/transactionCost endpoint is updated to support new transfer types. The change is backwards compatible.
- Existing v0/accTransactions endpoint converts outcomes of new transaction types to old ones.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## TODO

- [ ] update dependencies after concordium-client is properly updated
- [ ] discuss with Mjolner whether this way is better, or whether it is better to have a separate endpoint for checking support for transfer with memos.

