### PR TITLE
Docker/K8s: Only consider "enabled" reporter nodes

### DIFF
--- a/docker/docker-entrypoint_k8s-statefulset.sh
+++ b/docker/docker-entrypoint_k8s-statefulset.sh
@@ -10,9 +10,9 @@ pod_name="${K8S_POD_NAME}"
 # by stripping the longest prefix matching the pattern "*-" from 'pod_name'.
 index="${pod_name##*-}"
 
-# Parse reporter IP and DB credentials based on the pod index (using round-robin).
-# JSON format: "[{grpc: {host, port}, db: {host, name, port, user, password}}]".
-reporter_args_tsv="$(jq -r ".[${index} % (.|length)] | [.grpc.host, .grpc.port, .db.host, .db.port, .db.user, .db.name, .db.password] | @tsv" <<< "${reporters}")"
+# Parse reporter IP and DB credentials based on the pod index (using round-robin on "enabled" entries).
+# JSON format: "[{grpc: {host, port}, db: {host, name, port, user, password}, enabled}]".
+reporter_args_tsv="$(jq -r "map(select(.enabled)) | .[${index} % (.|length)] | [.grpc.host, .grpc.port, .db.host, .db.port, .db.user, .db.name, .db.password] | @tsv" <<< "${reporters}")"
 IFS=$'\t' read -r grpc_host grpc_port db_host db_port db_user db_name db_password <<< "${reporter_args_tsv}"
 
 # Invoke default entrypoint - inherits env vars and args.


### PR DESCRIPTION
## Purpose

Ensure that instances only connect to "enabled" reporter nodes.

## Changes

Add filter in `jq` query to only consider reporter node entries where `enabled` is set to `true`.