### PR TITLE
Do not create gtu-recepients table if gtu drop is not enabled.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -87,7 +87,8 @@ main = do
         Right (dropAccount, dropKeys) -> return . Just $ GTUDropData {..}
   Right ipInfo <- AE.eitherDecode' <$> LBS.readFile pcIpInfo
   runStderrLoggingT $ withPostgresqlPool pcDBConnString 10 $ \dbConnectionPool -> liftIO $ do
-    runSqlPool (runMigration migrateGTURecipient) dbConnectionPool
+    -- do not care about the gtu receipients database if gtu drop is not enabled
+    when (isJust gtuDropData) $ runSqlPool (runMigration migrateGTURecipient) dbConnectionPool
     runExceptT (mkGrpcClient pcGRPC (Just logm)) >>= \case
       Left err -> die $ "Cannot connect to GRPC endpoint: " ++ show err
       Right cfg -> do


### PR DESCRIPTION
## Purpose

If the wallet-proxy is not configured for GTU drop there is no need to create the g_t_u_recepients table.

## Changes

Do not run migration if the table is not going to be used.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.