### PR TITLE
Include encrypted transfers with memo in the encryptedOnly filter.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for wallet-proxy
 
+## 0.8.0
+ - Fix bug where encrypted transfers with memo were not included in transaction
+   list when the encrypted filter was applied.
+ - Do not create gtu drop table in the database if not configured for GTU drop.
+
 ## 0.7.0
 
  - Add support for transfers with a memo.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.7.1
+version:             0.8.0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -619,7 +619,8 @@ getAccountTransactionsWorker includeMemos addrText = do
           -- check if the transaction is encrypting, decrypting, or transferring an encrypted amount.
           in E.where_ $ extractedType E.==. E.val (Just "encryptedAmountTransfer") E.||.
                         extractedType E.==. E.val (Just "transferToEncrypted") E.||.
-                        extractedType E.==. E.val (Just "transferToPublic")
+                        extractedType E.==. E.val (Just "transferToPublic") E.||.
+                        extractedType E.==. E.val (Just "encryptedAmountTransferWithMemo")
         Just _ -> Nothing
 
       rawReason <- isJust <$> lookupGetParam "includeRawRejectReason"


### PR DESCRIPTION
## Purpose

Include encrypted transfers with memo in the onlyEncrypted filter.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
