### PR TITLE
Account aliases

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
  - Fix bug where encrypted transfers with memo were not included in transaction
    list when the encrypted filter was applied.
  - Do not create gtu drop table in the database if not configured for GTU drop.
+ - Add support for account aliases.
+
 
 ## 0.7.0
 

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -713,6 +713,7 @@ formatEntry includeMemos rawRejectReason i self (Entity key Entry{}, Entity _ Su
     AE.Success (Right v@BakingRewards{..}) ->
       return [
       "origin" .= object ["type" .= ("reward" :: Text)],
+        -- This lookup is correct in presence of aliases since rewards are given to canonical addresses.
         "total" .= Map.lookup self (accountAmounts stoBakerRewards), -- this should always return Just due to the way we look up.
         "details" .= object [
           "type" .= ("bakingReward" :: Text),
@@ -735,7 +736,7 @@ formatEntry includeMemos rawRejectReason i self (Entity key Entry{}, Entity _ Su
     AE.Success (Right v@FinalizationRewards{..}) ->
       return [
       "origin" .= object ["type" .= ("reward" :: Text)],
-      -- FIXME: Only works if canonical address.
+        -- This lookup is correct in presence of aliases since rewards are given to canonical addresses.
         "total" .= Map.lookup self (accountAmounts stoFinalizationRewards), -- this should always return Just due to the way we look up.
         "details" .= object [
           "type" .= ("finalizationReward" :: Text),


### PR DESCRIPTION
## Purpose

Support for account aliases. Closes #28 

## Changes

- The main change is that we have to take into account aliases when computing totals and subtotals in account transactions list.
- Account balance and nonce queries already support aliases since the node supports them.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
