### PR TITLE
Expose registered data in transaction list.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wallet-proxy
 
+## 0.8.1
+ - Add the data field to a transaction list response when the transaction is a
+   register data transaction.
+
 ## 0.8.0
  - Fix bug where encrypted transfers with memo were not included in transaction
    list when the encrypted filter was applied.

--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ It consists of the following fields:
   - `transferDestination`: account address of the destination of the transfer
   - `transferAmount`: amount of the transfer
   - in `v1` version if `type = transferWithScheduleAndMemo` then an additional field `memo` is present. It is a hex-encoded byte array.
+- The following field is present if the transaction is a register data
+  transaction.
+  - `registeredData`: hex encoding of the data that was registered
 
 For the purposes of the above, a simple transfer is a transaction of type `"transfer"` which transfers funds from one account to another.
 A transactions of type `"transfer"` is not considered a simple transfer if the destination is a smart contract instance.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.8.0
+version:             0.8.1
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -807,6 +807,8 @@ formatEntry includeMemos rawRejectReason i self (Entity key Entry{}, Entity _ Su
                                        addMemo mmemo [
                                          "transferDestination" .= etwsTo,
                                          "transferAmount" .= foldl' (+) 0 (map snd etwsAmount)]
+                                     (TSTAccountTransaction (Just TTRegisterData), [DataRegistered{..}]) ->
+                                       ["registeredData" .= drData]
                                      _ -> []), eventSubtotal self evts )
             TxReject reason ->
               let rawReason = if rawRejectReason then ["rawRejectReason" .= reason] else []


### PR DESCRIPTION
## Purpose

Expose the registered data in the transaction list response

## Changes

Add a field to the the transaction list response if transaction is a register data transaction.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
