### PR TITLE
Duplicate transactions will now return a 409 'Conflict' HTTP response code.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for wallet-proxy
 
+## Unreleased changes
+ - PUT'ing duplicate credential deployments or transfers will now yield a 409 'Conflict' HTTP response code.
+
 ## 0.8.1
  - Add the data field to a transaction list response when the transaction is a
    register data transaction.

--- a/README.md
+++ b/README.md
@@ -303,12 +303,24 @@ the node is alive the server will respond with a submission id which can be
 queried via the `/submissionStatus` endpoint.
 
 
+Submitting a duplicate credential will result in
+
+```console
+  {"error":3,"errorMessage":"The transaction is a duplicate"}
+```
+
 ## Submit transfer
 
 When submitting a transfer you should make a PUT request to `/v0/submitTransfer` endpoint.
 The data that should be sent is as the one returned from the library provided as part of the concordium-base repository.
 After submission of the transaction the responses are the same as for the submission of the credential. If successful
 a submission id is returned, which can be used to query the status of the transfer via the `/v0/submissionStatus` endpoint.
+
+Submitting a duplicate transaction will result in
+
+```console
+  {"error":3,"errorMessage":"The transaction is a duplicate"}
+```
 
 ## Get transactions
 

--- a/src/Internationalization/Base.hs
+++ b/src/Internationalization/Base.hs
@@ -29,6 +29,7 @@ data ErrorMessage
     | EMMissingParameter
     -- |Action not supported due to the node protocol version not allowing it.
     | EMActionNotCurrentlySupported
+    | EMDuplicate
 
 data I18n = I18n {
     i18nRejectReason :: RejectReason -> Text,

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -177,3 +177,4 @@ translation = I18n {..}
         i18nErrorMessage EMAccountDoesNotExist = "Account does not exist"
         i18nErrorMessage EMMissingParameter = "Missing parameter"
         i18nErrorMessage EMActionNotCurrentlySupported = "The required action is not supported. The node's protocol version is incompatible with it."
+        i18nErrorMessage EMDuplicate = "The transaction is a duplicate"


### PR DESCRIPTION
## Purpose

Solves https://github.com/Concordium/concordium-wallet-proxy/issues/35

Prior the wallet proxy has been unable to distinguish why transactions fails when send to the node. 
This has to some degree changed with https://github.com/Concordium/concordium-node/pull/217.

The wallet proxy can now report back to the callee if the transaction was a duplicate. 

A duplicate transaction will now yield a HTTP 409 'Conflict' response with the following content:
`{"error":3,"errorMessage":"The transaction is a duplicate"}`

Note. The current in use logic for this handling is quite fragile as it requires matching on a string which origins from the node and subsequently is being modified through the `concordium-client`. 

This solution should be revised when the concordium-client offers a richer type system for GRPC errors. 
The proposed solution should be sufficient for the current requirements and will improve the feedback for consumers of the `wallet-proxy.`

## Changes

`runGRPC` now checks whether the returned gRPC error stems from a duplicate transaction or not.
If the transaction is _duplicate_ then the proxy will now return a HTTP 409 response, otherwise it will function as before i.e., return a HTTP 502 response with the generic content: _Cannot communicate with node via GRPC endpoint._ 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
