### PR TITLE
Return estimated effective time for cooldowns.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+## 0.15.1
+ - add an estimate cooldown end to the `accBalance` query.
+
 ## 0.15.0
  - add `GET /v0/epochLength` endpoint
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ The `AccountBalance` value is always an object with the following four fields
     * `"change"` (required): indicating the kind of change which value is either `"reduceStake"` indicating that the
       baker's stake is reduced at the end of the cooldown period, or `"removeStake"` indicating that the baker is being
       removed at the end of the cooldown period.
-    * `"effectiveTime"` (required): the time at which the cooldown ends and the change takes effect, e.g. `"2022-03-30T16:43:53.5Z"`.
+    * `"effectiveTime"` (required): the time at which the cooldown ends, e.g. `"2022-03-30T16:43:53.5Z"`.
+    * `"estimatedChangeTime"` (optional, present if protocol version 4 or
+      later): an estimate of when the change actually takes effect, which is the
+      first payday after the cooldown ends, e.g. `"2022-03-30T16:43:53.5Z"`.
     * `"newStake"` (optional): This field is present if the value of the field `"change"` is `"reduceStake"`,
         and the value is the new stake after the cooldown.
 * `"accountDelegation"` (optional) if present indicates that this account is
@@ -157,7 +160,10 @@ The `AccountBalance` value is always an object with the following four fields
     * `"change"` (required): indicating the kind of change which value is either `"reduceStake"` indicating that the
       delegators's stake is reduced at the end of the cooldown period, or `"removeStake"` indicating that the delegator is being
       removed at the end of the cooldown period.
-    * `"effectiveTime"` (required): the time at which the cooldown ends and the change takes effect, e.g. `"2022-03-30T16:43:53.5Z"`.
+    * `"effectiveTime"` (required): the time at which the cooldown ends, e.g. `"2022-03-30T16:43:53.5Z"`.
+    * `"estimatedChangeTime"` (optional, present if protocol version 4 or
+      later): an estimate of when the change actually takes effect, which is the
+      first payday after the cooldown ends, e.g. `"2022-03-30T16:43:53.5Z"`.
     * `"newStake"` (optional): This field is present if the value of the field `"change"` is `"reduceStake"`,
         and the value is the new stake after the cooldown.
 
@@ -739,6 +745,7 @@ in the case that the baker is NOT in a cooldown period, or
     "bakerEquityCapital": "1000000000",
     "pendingChangeType": "ReduceBakerCapital",
     "effectiveTime": "2022-03-30T16:43:53.5Z"
+    "estimatedChangeTime": "2022-03-30T17:00:00.0Z"
 }
 ```
 in case that the baker's stake is reduced, or
@@ -746,6 +753,7 @@ in case that the baker's stake is reduced, or
 {
     "pendingChangeType": "RemovePool",
     "effectiveTime": "2022-03-31T23:54:48.25Z"
+    "estimatedChangeTime": "2022-04-01T06:00:00.0Z"
 }
 ```
 in case that the baker pool is removed.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.15.0
+version:             0.15.1
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -52,7 +52,6 @@ import Data.Time.Clock as Clock
 
 import Paths_wallet_proxy (version)
 import Concordium.Types
-import Concordium.Types.Parameters (TimeParameters(..))
 import Concordium.Types.Queries
 import Concordium.Types.Accounts
 import Concordium.Types.HashableTo
@@ -255,11 +254,11 @@ getRewardPeriodLength lfb = do
            pv <- obj AE..: "protocolVersion"
            chainParameters <- updates AE..: "chainParameters"
            if pv >= P4 then
-             Just <$> (chainParameters AE..: "timeParameters")
+             Just <$> (chainParameters AE..: "rewardPeriodLength")
            else return Nothing
      summary <- either fail return =<< getBlockSummary lfb
-     timeParams <- liftResult (parse timeParametersParser summary)
-     return (Right (_tpRewardPeriodLength <$> timeParams))
+     rpLength <- liftResult (parse timeParametersParser summary)
+     return (Right rpLength)
 
 -- |Get the balance of an account.  If successful, the result is a JSON
 -- object consisting of the following optional fields:


### PR DESCRIPTION
## Purpose

Return the estimated effective time of the end of cooldown, taking into account the payday duration.

## Changes

Add a new field to the response for getAccountBalance that estimates when the cooldown will end. This is only the estimate since payday duration can in principle change by the end of the cooldown, although this is unlikely to happen in practice.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.