### PR TITLE
Forward cookies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased changes
 
+## 0.19
+
+- add cookie forwarding
+- introduce new configuration options
+  - `--log-level` for controlling log output
+  - `grpc-timeout` for controlling the timeout of requests to the node
+  - `--secure` which enables TLS support
+
 ## 0.18
 
 - add `GET /v0/CIS2Tokens` endpoint.

--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,8 @@ wallet-proxy --grpc-ip 127.0.0.1\
              --forced-update-config-v0 forced-update-config-v0.json\
              --forced-update-config-v1 forced-update-config-v1.json\
              --health-tolerance 30
+             --log-level debug
+             --grpc-timeout 15
 ```
 
 where
@@ -1031,6 +1033,10 @@ where
 - `--forced-update-config-v0 forced-update-config-v0.json` file with app update configuration for the old mobile wallet
 - `--forced-update-config-v1 forced-update-config-v1.json` file with app update configuration for the new mobile wallet
 - `--health-tolerance 30` tolerated age of last final block in seconds before the health query returns false
+- `--log-level debug` means all logs above debug will be printed. Options are
+  `off`, `warning`, `error`, `info`, `debug`, `trace`.
+- `--grpc-timeout 15` means that all requests to the node must terminate in at
+  most 15s, otherwise they will be cancelled.
 
 If the node only supports TLS connections then the wallet-proxy must be started
 with the `--secure` flag to enable its use.

--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,9 @@ where
 - `--forced-update-config-v1 forced-update-config-v1.json` file with app update configuration for the new mobile wallet
 - `--health-tolerance 30` tolerated age of last final block in seconds before the health query returns false
 
+If the node only supports TLS connections then the wallet-proxy must be started
+with the `--secure` flag to enable its use.
+
 ## Identity providers metadata files
 
 ### For the version 0 identity issuance flow

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,6 +23,7 @@ import Control.Monad.Logger
 
 import Concordium.Client.GRPC
 import Concordium.Client.Commands as CMDS
+import Concordium.Client.Types.GRPC
 import Options.Applicative
 import Data.Range.Parser
 
@@ -154,4 +155,4 @@ main = do
         runClient cfg (withLastFinalBlockHash Nothing getCryptographicParameters) >>= \case
           Left err -> die $ "Cannot obtain cryptographic parameters due to network error: " ++ show err
           Right (Left err) -> die $ "Cannot obtain cryptographic parameters due to unexpected response: " ++ err
-          Right (Right globalInfo) -> runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg, ..}
+          Right (Right (GRPCResponse _ globalInfo)) -> runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg, ..}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,7 +24,7 @@ import Control.Monad.Logger
 
 import Concordium.Client.GRPC
 import Concordium.Client.Commands as CMDS
-import Concordium.Client.Types.GRPC
+import Concordium.Client.Runner.Helper
 import Options.Applicative
 import Data.Range.Parser
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -59,6 +59,7 @@ parser = info (helper <*> parseProxyConfig)
                               (CMDS.grpcTarget backend)
                               (CMDS.grpcRetryNum backend)
                               (Just 30)
+                              (CMDS.grpcUseTls backend)
 
 runSite :: YesodDispatch site => Int -> Network.Wai.Handler.Warp.HostPreference -> site -> IO ()
 runSite port host site = do

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,12 +15,16 @@ drop_account_file="${DROP_ACCOUNT_FILE-}"
 forced_update_config_file_v0="${FORCED_UPDATE_CONFIG_FILE_V0-}"
 forced_update_config_file_v1="${FORCED_UPDATE_CONFIG_FILE_V1-}"
 use_tls="${USE_TLS}"
+log_level="${LOG_LEVEL:-debug}" # default log level is debug
+grpc_timeout="${GRPC_TIMEOUT:-15}"
 
 args=(
 	--grpc-ip "${grpc_host}"
 	--grpc-port "${grpc_port}"
 	--ip-data "${ip_data_file}"
     --ip-data-v1 "${ip_data_file_v1}"
+    --log-level "${log_level}"
+    --grpc-timeout "${grpc_timeout}"
 	--db "host=${db_host} port=${db_port} user=${db_user} dbname=${db_name} password=${db_password}"
 )
 if [ -n "${drop_account_file}" ]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,6 +14,7 @@ db_password="${DB_PASSWORD}"
 drop_account_file="${DROP_ACCOUNT_FILE-}"
 forced_update_config_file_v0="${FORCED_UPDATE_CONFIG_FILE_V0-}"
 forced_update_config_file_v1="${FORCED_UPDATE_CONFIG_FILE_V1-}"
+use_tls="${USE_TLS}"
 
 args=(
 	--grpc-ip "${grpc_host}"
@@ -30,6 +31,9 @@ if [ -n "${forced_update_config_file_v0}" ]; then
 fi
 if [ -n "${forced_update_config_file_v1}" ]; then
 	args+=( --forced-update-config-v1 "${forced_update_config_file_v1}" )
+fi
+if [ -n "${use_tls}" ]; then
+	args+=( --secure )
 fi
 
 # Inherits env vars and args.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.18.0
+version:             0.19.0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,9 @@ description:         Please see the README on GitHub at <https://github.com/Conc
 dependencies:
 - base >=4.7 && < 5
 - bytestring >= 0.10
+- case-insensitive >= 1.2.1.0
 - concordium-base
+- cookie >= 0.4.5
 - cereal >= 0.5.7
 - unordered-containers >= 0.2.9
 - containers >= 0.6

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -40,7 +40,7 @@ convertLogLevel ll = case ll of
   Logger.LevelWarn -> LLWarning
   Logger.LevelError -> LLError
   Logger.LevelOther s ->
-    if Text.toUpper s == Text.pack "trace"
+    if Text.toLower s == Text.pack "trace"
     then LLTrace
     else LLOff
 

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Logging(
+      Logging.LogLevel(..)
+    , filterL
+) where
+
+import           Control.Monad.Logger
+import           Data.Char
+import           Data.Text                  hiding (map)
+import           Data.String
+
+-- basically lifted from Concordium.Logger
+data LogLevel
+  = LLOff
+  | LLError
+  | LLWarning
+  | LLInfo
+  | LLDebug
+  | LLTrace
+  deriving (Eq, Ord)
+
+instance Show Logging.LogLevel where
+  show LLOff = "OFF"
+  show LLError = "ERROR"
+  show LLWarning = "WARNING"
+  show LLInfo = "INFO"
+  show LLDebug = "DEBUG"
+  show LLTrace = "TRACE"
+
+instance IsString Logging.LogLevel where
+  fromString s
+    | sU == show LLOff = LLOff
+    | sU == show LLError = LLError
+    | sU == show LLWarning = LLWarning
+    | sU == show LLInfo = LLInfo
+    | sU == show LLDebug = LLDebug
+    | sU == show LLTrace = LLTrace
+    | otherwise = LLOff
+    where sU = map Data.Char.toUpper s
+
+convertLogLevel :: Control.Monad.Logger.LogLevel -> Logging.LogLevel 
+convertLogLevel ll = case ll of
+  LevelDebug -> LLDebug 
+  LevelInfo -> LLInfo
+  LevelWarn -> LLWarning
+  LevelError -> LLError
+  LevelOther s ->
+    if   Data.Text.toUpper s == Data.Text.pack "TRACE"
+    then LLTrace
+    else LLOff
+
+filterL :: Logging.LogLevel -> LoggingT m a -> LoggingT m a
+filterL ll = filterLogger (\_ l -> convertLogLevel l <= ll)

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -90,6 +90,7 @@ import Concordium.ID.Types (addressFromText, addressToBytes, KeyIndex, Credentia
 import Concordium.Crypto.SignatureScheme (KeyPair)
 import Concordium.Crypto.ByteStringHelpers (ByteStringHex(..))
 import Concordium.Common.Version
+import qualified Logging
 
 import Internationalization
 
@@ -177,7 +178,8 @@ data Proxy = Proxy {
   healthTolerance :: Int,
   globalInfo :: Value,
   ipInfo :: Value,
-  ipInfoV1 :: Value
+  ipInfoV1 :: Value,
+  logLevel :: Logging.LogLevel
 }
 
 -- | Data needed for GTU drops.
@@ -253,6 +255,8 @@ instance Yesod Proxy where
         NotAuthenticated -> RequestInvalid
         PermissionDenied {} -> RequestInvalid
         BadMethod {} -> RequestInvalid
+
+  shouldLogIO Proxy{..} _source level = return $ Logging.convertLogLevel level <= logLevel
 
 -- |Terminate execution and respond with 400 status code with the given error
 -- description.

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -312,8 +312,8 @@ runGRPC c k = do
   let
     exHandler :: SomeException -> IO (Either String a, Map.Map BS.ByteString BS.ByteString)
     exHandler e = pure (Left $ show e, Map.empty)
-  $(logOther "Trace") $ "Invoking runClientWithExtraHeaders with headers: " <> Text.pack (show cookies)
-  liftIO (fmap (\(x, y) -> (left show x, y)) (runClientWithExtraHeaders cookies cfg c) `catch` exHandler) >>= \case
+  $(logOther "Trace") $ "Invoking queries with headers: " <> Text.pack (show cookies)
+  liftIO (fmap (\(x, y) -> (left show x, y)) (runClientWithCookies cookies cfg c) `catch` exHandler) >>= \case
     (Left err, _) -> do
       $(logError) $ "Internal error accessing GRPC endpoint: " <> Text.pack err
       i <- internationalize


### PR DESCRIPTION
## Purpose

Allows for insertion of load-balancer between wallet-proxy endpoints. To facilitate this, user agents need to be able to include cookies in requests, and the wallet-proxy should forward these accordingly. Similarly, set-cookie headers should be retained in responses forwarded to client.

Depends on:

https://github.com/Concordium/concordium-client/pull/179

## Changes

- The wallet proxy extracts cookie headers from the user's initial (yesod) and includes them in the GRPC request.
- The wallet proxy extracts set-cookie headers from the GRPC response and includes them in the (yesod) response.
- In case the wallet proxy makes a chain of nested GRPC calls to serve the user request, set cookie headers that are received in a GRPC response is included in the next GRPC request. In this way, the wallet-proxy acts as a client.
- Added trace-level logging of cookies and headers that are sent and received.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.