### PR TITLE
Upgrade compiler tooling and libraries.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ on:
 
 env:
   RUST: 1.62
-  GHC: 9.0.2
+  GHC: 9.2.5
 
 jobs:
   concordium-client-build-and-test:

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,10 +46,10 @@ extra-deps:
 - ./deps/concordium-client/
 
 - github: Concordium/http2-client
-  commit: 75623c0ef961a7642521d5671c2a406aec3420b6
+  commit: 8087dfd416118064934affb35caab811a8a70233
 
 - github: Concordium/http2-grpc-haskell
-  commit: cbfa67776fa2247a5e013f3a275b5164e00c5e10
+  commit: 7f4f4955cd64d867b9fda951600a445653f5b098
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-19.6
+resolver: lts-20.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -28,6 +28,7 @@ resolver: lts-19.6
 #   subdirs:
 #   - auto-update
 #   - wai
+
 packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver.
@@ -46,10 +47,10 @@ extra-deps:
 - ./deps/concordium-client/
 
 - github: Concordium/http2-client
-  commit: 87c4306a624ff490ac9bd92e075ff09f14c341f4
+  commit: 75623c0ef961a7642521d5671c2a406aec3420b6
 
 - github: Concordium/http2-grpc-haskell
-  commit: 6787bbe9445e841c02c8b1f699304be15b3c3e5a
+  commit: cbfa67776fa2247a5e013f3a275b5164e00c5e10
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,6 @@ resolver: lts-20.4
 #   subdirs:
 #   - auto-update
 #   - wai
-
 packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver.


### PR DESCRIPTION
## Purpose

Upgrade stackage snapshot to `lts-20.4` and ghc to 9.2.5.

## Changes

- Bump `resolver`in `stack.yaml` and fix build errors and warnings.
- Update dependencies on `http2-client` and `http2-grpc-haskell` to ones that are updated to support `lts-20.4`.

## Depends on

https://github.com/Concordium/concordium-client/pull/196
https://github.com/Concordium/http2-grpc-haskell/pull/3
https://github.com/Concordium/http2-client/pull/3

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.