### PR TITLE
Migrate wallet-proxy to use the node GRPC API V2.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 0.26
+
 - The `--grpc-authentication-token` option has been removed.
 - The wallet proxy now uses the node GRPC API V2 to interact with the node.
   The port specified with the `--grpc-port` option must therefore now be one

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,11 +3,11 @@
 ## Unreleased changes
 
 - The `--grpc-authentication-token` option has been removed.
-- The wallet proxy now internally uses the node GRPC API V2 to interact with
-  the node. The port specified with the `--grpc-port` option must therefore
-  now be one on which this is served. Since the default port on which the V2
-  GRPC API is served by a node is 20000, the default value of this option has
-  been updated to reflect this.
+- The wallet proxy now uses the node GRPC API V2 to interact with the node.
+  The port specified with the `--grpc-port` option must therefore now be one
+  on which this is served. Since the default port on which the V2 GRPC API is
+  served by a node is 20000, the default value of this option has been updated
+  to reflect this.
 
 ## 0.25.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- The `--grpc-authentication-token` option has been removed.
+- The wallet proxy now internally uses the V2 GRPC API to interact with the node.
+
 ## 0.25.1
 
 - Fix displaying `message` in contract updates. Use hex consistently.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,11 @@
 ## Unreleased changes
 
 - The `--grpc-authentication-token` option has been removed.
-- The wallet proxy now internally uses the V2 GRPC API to interact with the node.
+- The wallet proxy now internally uses the node GRPC API V2 to interact with
+  the node. The port specified with the `--grpc-port` option must therefore
+  now be one on which this is served. Since the default port on which the V2
+  GRPC API is served by a node is 20000, the default value of this option has
+  been updated to reflect this.
 
 ## 0.25.1
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -166,6 +166,9 @@ main = do
     runExceptT (mkGrpcClient pcGRPC (Just logm)) >>= \case
       Left err -> die $ "Cannot connect to GRPC endpoint: " ++ show err
       Right cfg -> do
+        let globalInfo = object [ "v" .= toJSON (0 :: Integer), "value" .= toJSON (0 :: Integer) ]
+        runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg,..}
+        {-
         -- The getCryptographicParameters returns a versioned cryptographic parameters object, which is what we need.
         -- Because these parameters do not change we only look them up on startup, and store them.
         runClient cfg (getCryptographicParametersV2 LastFinal) >>= \case
@@ -176,3 +179,4 @@ main = do
               let globalInfo = object [ "v" .= toJSON (0 :: Integer), "value" .= toJSON cParams ]
               runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg,..}
             Left (_, err) -> die $ "Cannot obtain cryptographic parameters due to unexpected response: " ++ err
+            -}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,6 +24,7 @@ import Control.Monad.Logger
 
 import Concordium.Client.GRPC
 import Concordium.Client.Commands as CMDS
+import Concordium.Common.Version (Version(Version))
 import Options.Applicative
 import Data.Range.Parser
 
@@ -162,7 +163,7 @@ main = do
     runExceptT (mkGrpcClient pcGRPC (Just logm)) >>= \case
       Left err -> die $ "Cannot connect to GRPC endpoint: " ++ show err
       Right cfg -> do
-        let globalInfo = object [ "v" .= toJSON (0 :: Integer), "value" .= toJSON (0 :: Integer) ]
+        let globalInfo = object [ "v" .= toJSON (Version 0), "value" .= toJSON (0 :: Integer) ]
         runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg,..}
         {-
         -- The getCryptographicParameters returns a versioned cryptographic parameters object, which is what we need.
@@ -171,8 +172,7 @@ main = do
           Left err -> die $ "Cannot obtain cryptographic parameters due to network error: " ++ show err
           Right res -> case getResponseValue res of
             Right cParams -> do
-              -- VH/FIXME: What should "v" be? It was returned the old API.
-              let globalInfo = object [ "v" .= toJSON (0 :: Integer), "value" .= toJSON cParams ]
+              let globalInfo = object [ "v" .= toJSON (Version 0), "value" .= toJSON cParams ]
               runSite 3000 "0.0.0.0" Proxy{grpcEnvData=cfg,..}
             Left (_, err) -> die $ "Cannot obtain cryptographic parameters due to unexpected response: " ++ err
             -}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,12 +24,8 @@ import Control.Monad.Logger
 
 import Concordium.Client.GRPC
 import Concordium.Client.Commands as CMDS
-import Concordium.Client.Runner.Helper
 import Options.Applicative
 import Data.Range.Parser
-import Concordium.Client.GRPC2 (getCryptographicParametersV2)
-import Concordium.GRPC2 (BlockHashInput(LastFinal))
-import Data.Coerce (coerce)
 
 data ProxyConfig = ProxyConfig {
   pcGRPC :: GrpcConfig,

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
 - persistent-template >= 2.7
 - persistent-postgresql >= 2.9
 - persistent >= 2.9.2
+- microlens-platform
 - monad-logger >= 0.3.30
 - resource-pool >= 0.2.3.2
 - conduit == 1.3.*

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ dependencies:
 - conduit-extra == 1.3.*
 - esqueleto
 - http-types >= 0.12
+- http2-grpc-types >= 0.5
 - yesod >= 1.6
 - warp >= 3.2
 - time

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.25.1
+version:             0.26
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -353,7 +353,7 @@ runGRPC = runGRPCWithCustomError Nothing
 -- error if the returned @GRPCResult@ is not @StatusOk@, or if it is @StatusOk (Left err)@. Otherwise the return value of
 -- type @a@ is mapped into a @Handler TypedContent@ under the provided callback.
 --
--- Client errors are mapped to status @badGateway502@ and error code @InternalError@ and returned the response by default.
+-- Client errors are mapped to status @badGateway502@ and error code @InternalError@ and returned in the response by default.
 -- These values can be overridden by supplying the value @ClientError@ in the supplied @ResponseOnError@. Otherwise, the
 -- GRPC call was successful and the following default mapping applies:
 --
@@ -367,8 +367,6 @@ runGRPC = runGRPCWithCustomError Nothing
 --   supplying @StatusNotOkError a@ in the @ResponseOnError@.
 -- - @RequestFailed@ maps to status @badGateway502@ and error code @InternalError@. These can be overridden by supplying
 --   @RequestFailedError@ in the @ResponseOnError@.
--- These can be overridden by supplying @ClientError@ in a @ResponseOnError@. If the GRPC call
--- succeeded, and no client error occurred, then
 runGRPCWithCustomError :: Maybe ResponseOnError
                        -> ClientMonad IO (GRPCResult (Either String a)) -- ^ The @ClientMonad@ to run.
                        -> (a -> Handler TypedContent) -- ^ The handler.

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -577,7 +577,7 @@ doParseAccountAddress :: Text -> Text -> Handler AccountAddress
 doParseAccountAddress ctx addrText =
   case addressFromText addrText of
     Left _ -> do
-      $(logInfo) $
+      $(logOther "Trace") $
           "Invalid account address '"
         <> addrText
         <> "' for '" <> ctx <> "' request."
@@ -2081,5 +2081,5 @@ getEpochLengthR :: Handler TypedContent
 getEpochLengthR =
     runGRPC getConsensusInfo $ \cInfo -> do
       let epochLengthObject = object ["epochLength" .= csEpochDuration cInfo]
-      $(logInfo) "Successfully got epoch length."
+      $(logOther "Trace") "Successfully got epoch length."
       sendResponse $ toJSON epochLengthObject

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -621,9 +621,8 @@ doParseAccountAddress ctx addrText =
     Right addr -> return addr
 
 -- |Returns a handler which attempts to get the next account nonce of the specified address.
--- If the address could not be parsed, an error is logged and a HTTP response with status
--- code @400@ is returned. If the account does not exist, a HTTP response with status
--- code @404@ is returned
+-- If the address could not be parsed, a HTTP response with status code @400@ is returned.
+-- If the account does not exist, a HTTP response with status code @404@ is returned
 getAccountNonceR :: Text -> Handler TypedContent
 getAccountNonceR addrText = do
   addr <- doParseAccountAddress "getAccountNonce" addrText

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -93,7 +93,7 @@ import Concordium.Client.Types.Transaction(transferWithScheduleEnergyCost,
                                            minimumCost,
                                            accountDecryptPayloadSize, delegationConfigureEnergyCost, registerDelegationPayloadSize, updateDelegationPayloadSize, removeDelegationPayloadSize, bakerConfigurePayloadSize, bakerConfigureEnergyCostWithKeys, bakerConfigureEnergyCostWithoutKeys
                                            )
-import Concordium.ID.Types (addressFromText, addressToBytes, KeyIndex, CredentialIndex)
+import Concordium.ID.Types (addressFromText, KeyIndex, CredentialIndex)
 import Concordium.Crypto.SignatureScheme (KeyPair)
 import Concordium.Crypto.SHA256 (Hash)
 import Concordium.Crypto.ByteStringHelpers (ByteStringHex(..))

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -862,8 +862,10 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
               chainParamsRes <- getBlockChainParametersV2 Best
               case getResponseValueAndHeaders chainParamsRes of
                 Left err -> fail err
-                Right (EChainParametersAndKeys (ecpParams :: ChainParameters' cpv) _, hds) -> do
-                  return $ StatusOk $ GRPCResponse hds (Right (_erEnergyRate $ _cpExchangeRates ecpParams, csProtocolVersion cs))
+                Right (EChainParametersAndKeys ecpParams _, hds) -> do
+                  return $
+                    StatusOk $
+                      GRPCResponse hds (Right (_erEnergyRate $ _cpExchangeRates ecpParams, csProtocolVersion cs))
       withExchangeRate = runGRPCV2 fetchUpdates
 
 putCredentialR :: Handler TypedContent

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -427,9 +427,8 @@ runGRPCWithCustomError resp c k = do
           return $
             Left (RequestFailedError, badGateway502, InternalError, EMGRPCErrorResponse "Unable to communicate with the node.")
   case responseInfoOrErrorData of
-    -- Send an error response, potentially overriding default values.
+    -- An error occurred. Send an error response, potentially overriding default values.
     Left (errType, status, errCode, errMsg) -> do
-      -- Use the specied error types here.
       (status', errCode', errMsg') <- case resp of
         -- Custom error information was provided.
         Just (onErrType, statusM, errCodeM, errMsgM) ->
@@ -437,7 +436,7 @@ runGRPCWithCustomError resp c k = do
           if errType == onErrType
             then return (fromMaybe status statusM, fromMaybe errCode errCodeM, fromMaybe errMsg errMsgM)
             else return (status, errCode, errMsg)
-        -- No custom error information was provided.
+        -- Otherwise, no custom error information was provided.
         Nothing -> return (status, errCode, errMsg)
       i <- internationalize
       sendResponseStatus status' $ object [

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -1764,7 +1764,6 @@ putGTUDropR addrText = do
                           $(logWarn) (Text.pack e)
                           respond400Error EMConfigurationError RequestInvalid
   where
-    accountToText = Text.decodeUtf8 . addressToBytes
     doGetAccInfo :: AccountAddress -> ClientMonad IO (GRPCResult (Either String (Nonce, Amount)))
     doGetAccInfo t = do
       aiRes <- getAccountInfo (AccAddress t) LastFinal

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -325,11 +325,11 @@ type ResponseOnError = (ErrorType, Maybe Status, Maybe ErrorCode, Maybe ErrorMes
 
 -- |Error types that can occur internally in @runGRPCWithCustomError@.
 data ErrorType =
-    ClientError
-  | InvariantError
-  | StatusInvalidError
-  | StatusNotOkError GRPCStatusCode
-  | RequestFailedError
+    ClientError -- ^ A client error occurred.
+  | InvariantError -- ^ The GRPC invocation succeeded with status code 'OK', but some invariant error occurred, e.g. when converting the payload.
+  | StatusInvalidError -- ^ An invalid GRPC status code was present in the response.
+  | StatusNotOkError GRPCStatusCode -- ^ A non-'OK' GRPC status code was present in the response.
+  | RequestFailedError -- ^ The GRPC invocation failed.
   deriving (Eq)
 
 -- |Run a GRPC request.

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -588,10 +588,6 @@ getAccountBalanceR addrText = do
         (Right lastFinBalF, Left bestBal) -> runGRPC (getRewardPeriodLengthV2 lastFinBlock) $ \rpl -> response (Just (lastFinBalF rpl)) bestBal
         (Right lastFinBalF, Right bestBalF) -> runGRPC (getRewardPeriodLengthV2 lastFinBlock) $ \rpl -> response (Just (lastFinBalF rpl)) (Just (bestBalF rpl))
   where
-    -- VH/FIXME: Should this not ideally be a chain of handlers in some CPS style? In this
-    --           case it seems better responses could be returned at each step like that,
-    --           since "fail" seems to return status code 500. It seems like this may be the case
-    --           in other places as well.
     doGetBal :: ClientMonad IO (GRPCResultV2 (FromProtoResult (AccountInfo, AccountInfo, Maybe UTCTime, Duration, BlockHash)))
     doGetBal = do
       accAddr <- parseAccountAddress addrText

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -619,7 +619,6 @@ liftResult :: MonadFail m => Result a -> m a
 liftResult (Success s) = return s
 liftResult (Error err) = fail err
 
-{-
 getAccountNonceR :: Text -> Handler TypedContent
 getAccountNonceR addrText = do
   runGRPCV2
@@ -631,14 +630,7 @@ getAccountNonceR addrText = do
       return $ StatusOk $ GRPCResponse hds (Right v))
     (\v -> do
       $(logInfo) "Successfully got nonce."
-      sendResponse $ object [])
--}
-
-getAccountNonceR :: Text -> Handler TypedContent
-getAccountNonceR addrText =
-    runGRPC (getNextAccountNonce addrText) $ \v -> do
-      $(logInfo) "Successfully got nonce."
-      sendResponse v
+      sendResponse $ toJSON v)
 
 -- |Get the account encryption key at the best block.
 -- Return '404' status code if account does not exist in the best block at the moment.


### PR DESCRIPTION
## Purpose

Migrate the client to use the node GRPC API V2.

Depends on https://github.com/Concordium/concordium-client/pull/243

## Changes

### General
- [x] `globalInfo` (chain parameters) in `Main`.

### Proxy handlers
- [x] AccountBalanceR
- [x] AccountNonceR
- [x] AccountEncryptionKeyR
- [x] AccountTransactionsV0R
- [x] TransactionCostR
- [x] SubmissionStatusR
- [x] CredentialR
- [x] TransferR
- [x] GTUDropR
- [x] GlobalFileR
- [x] HealthR
- [x] AccountTransactionsV1R
- [x] BakerPoolR
- [x] ChainParametersR
- [x] NextPaydayR
- [x] PassiveDelegationR
- [x] EpochLengthR
- [x] CIS2Tokens
- [x] CIS2TokenMetadata
- [x] CIS2TokenBalance

### Handlers that do not need migration
- [x] AppSettingsV0
- [x] AppSettingsV1
- [x] TermsAndConditionsVersion
- [x] IpsR
- [x] IpsV1R

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.