### PR TITLE
Fix transaction cost.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 0.26.1
+
+- Fix bug in transactionCost which expected a block hash header in response.
+
 ## 0.26
 
 - The `--grpc-authentication-token` option has been removed.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.26
+version:             0.26.1
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -830,9 +830,8 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
         consensusInfoRes <- getConsensusInfo
         case getResponseValueAndHeaders consensusInfoRes of
             Left errRes -> return errRes
-            Right (csRes, hds) -> do
-              best <- getBlockHashHeader hds
-              chainParamsRes <- getBlockChainParameters (Given best)
+            Right (csRes, _) -> do
+              chainParamsRes <- getBlockChainParameters Best
               case getResponseValueAndHeaders chainParamsRes of
                 Left errRes -> return errRes
                 Right (cpksRes, hds') -> do


### PR DESCRIPTION
## Purpose

Fix transactionCost endpoint.

consensusInfo does not return a block hash, since it does not make sense for it.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.