### PR TITLE
Revert behaviour in cases of not found accounts.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+## 0.26.2
+
+- Revert behaviour in case when accounts are not found. Now, again, a status
+  code 200 is returned with an empty object.
+
 ## 0.26.1
 
 - Fix bug in transactionCost which expected a block hash header in response.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.26.1
+version:             0.26.2
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Revert behaviour in case of accounts that do  not exist. Now again a status code 200 is returned with an empty object.

This behaviour is relied upon by the android wallet.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

