### PR TITLE
Don't reconnect on request failures.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+## 0.29.1
+
+- Improve reconnect handling. If the request to the node times out or fails due
+  to resource exhaustion then the connection to the node is longer reset.
+
 ## 0.29.0
 
 - Add an optional `success` field to the `transactionStatus` response if

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.29.0
+version:             0.29.1
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
   commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
 
 - github: Concordium/http2-grpc-haskell
-  commit: a4a0a31d44f754bf61868552ee5b256d94eed4de
+  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens


### PR DESCRIPTION
## Purpose

Respond with 503 in cases where the node responds with some form of resource exhaustion.


See https://github.com/Concordium/concordium-client/pull/280

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
