### PR TITLE
Update Haskell to LTS 22.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   RUST: 1.68
-  GHC: 9.2.7
+  GHC: 9.6.4
 
 jobs:
   fourmolu:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Update GHC version to 9.6.4 (lts-22.9).
+
 ## 0.29.2
 
 - Rename baker to validator in transaction outcomes.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ import qualified Network.Wai.Handler.Warp
 import Proxy
 import Yesod
 
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Logger
 import System.Exit (die)

--- a/package.yaml
+++ b/package.yaml
@@ -21,41 +21,29 @@ extra-source-files:
 description:         Please see the README on GitHub at <https://github.com/Concordium/concordium-wallet-proxy#readme>
 
 dependencies:
-- base >=4.7 && < 5
-- bytestring >= 0.10
-- case-insensitive >= 1.2.1.0
-- concordium-base
-- cookie >= 0.4.5
-- cereal >= 0.5.7
-- unordered-containers >= 0.2.9
-- containers >= 0.6
-- mtl >= 2.2.2
 - aeson >= 1.4.2
-- text >= 1.2.3
+- base >=4.7 && < 5
 - base16-bytestring >= 0.1.1.6
-- recursion-schemes >= 5.1
-- vector >= 0.12
-- split
-- directory >= 1.3
-- either
-- filepath >= 1.4
-- random >= 1.1
-- persistent-template >= 2.7
-- persistent-postgresql >= 2.9
-- persistent >= 2.9.2
-- microlens-platform
-- monad-logger >= 0.3.30
-- resource-pool >= 0.2.3.2
+- bytestring >= 0.10
+- cereal >= 0.5.7
+- concordium-base
+- concordium-client
 - conduit == 1.3.*
 - conduit-extra == 1.3.*
+- containers >= 0.6
+- cookie >= 0.4.5
 - esqueleto
 - http-types >= 0.12
 - http2-grpc-types >= 0.5
-- yesod >= 1.6
-- warp >= 3.2
-- time
+- microlens-platform
+- monad-logger >= 0.3.30
+- persistent >= 2.9.2
+- persistent-postgresql >= 2.9
+- random >= 1.1
 - range >= 0.3
-- concordium-client
+- text >= 1.2.3
+- time
+- yesod >= 1.6
 
 default-extensions:
 - RecordWildCards
@@ -66,6 +54,7 @@ default-extensions:
 - FlexibleInstances
 - FunctionalDependencies
 - GeneralizedNewtypeDeriving
+- TypeOperators
 
 library:
   source-dirs: src
@@ -88,8 +77,10 @@ executables:
     - -with-rtsopts=-N
     # - -dynamic
     dependencies:
-    - wallet-proxy
+    - mtl
     - optparse-applicative
+    - wallet-proxy
+    - warp
 
 tests:
   wallet-proxy-test:

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -31,7 +31,7 @@ import Data.Ratio
 
 import Control.Arrow (first, left)
 import Control.Exception (SomeException, catch)
-import Control.Monad.Except
+import Control.Monad
 import Data.Aeson (Result (..), fromJSON, withObject)
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as KM

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.4
+resolver: lts-22.9
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -46,14 +46,18 @@ extra-deps:
 - ./deps/concordium-client/
 
 - github: Concordium/http2-client
-  commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
+  commit: af0edc5fba5265ba9a4b2f91cfc3c466e4c82197
 
 - github: Concordium/http2-grpc-haskell
-  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
+  commit: 61fe303559bab35bc8da0ead4b41448f84b529b2
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens
     - http2-grpc-types
+
+- proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
+- proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
+- ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
 
 extra-lib-dirs:
 - ./deps/concordium-client/deps/concordium-base/lib


### PR DESCRIPTION
## Purpose

Update to GHC 9.6.4, LTS 22.9.

## Changes

- Update concordium-client
- Clean up dependencies
- Update `http2-client` and `http2-grpc-haskell`
- Fix proto-lens related dependencies (outside current stackage).

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
