### PR TITLE
Update base image tag for Rust 1.73

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: wallet-proxy
   # the build image
-  BASE_IMAGE_TAG: rust1.68-ghc9.6.4
+  BASE_IMAGE_TAG: rust1.73-ghc9.6.4
 
 jobs:
   build-and-push-image:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.32.0-0
+version:             0.32.0-1
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Docker image tag for `concordium/base` is updated for Rust version 1.73, required for building dependencies.

## Changes

- Update base tag.
- Increment build number.

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
