### PR TITLE
Show correct account "at disposal" balance with node < 7.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 0.32.1
+
+- Endpoint `/v1/accBalance` displays correct `accountAtDisposal` when used with a node version < 7.
+
 ## 0.32.0
 
 - Add endpoint `/v1/accBalance` that exposes the cooldowns on the account

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.32.0-1
+version:             0.32.1-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

This ensures that the endpoint `/v1/accBalance` displays the correct `accountAtDisposal` when used with a node version < 7. This is to support deploying updated wallets before the node version 7 is rolled out.

## Changes

- Update the `concordium-client` dependency. The updated version calculates the available amount if it isn't provided by the node, instead of defaulting it to 0.
- Bump version.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
