### PR TITLE
Update to GHC 9.6.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  RUST: 1.73
-  GHC: 9.6.4
+  RUST: 1.82
+  GHC: 9.6.6
 
 jobs:
   fourmolu:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: wallet-proxy
   # the build image
-  BASE_IMAGE_TAG: rust1.73-ghc9.6.4
+  BASE_IMAGE_TAG: rust-1.82_ghc-9.6.6-1
 
 jobs:
   build-and-push-image:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Update GHC version to 9.6.6 (lts-22.39).
+
 ## 0.32.1
 
 - Endpoint `/v1/accBalance` displays correct `accountAtDisposal` when used with a node version < 7.

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -184,6 +184,8 @@ translation = I18n{..}
                 DelegateToBaker bid -> "staking pool " <> Text.pack (show bid)
     i18nEvent DelegationAdded{..} = "Added delegator " <> descrDelegator edaDelegatorId edaAccount
     i18nEvent DelegationRemoved{..} = "Removed delegator " <> descrDelegator edrDelegatorId edrAccount
+    i18nEvent BakerSuspended{..} = "Validator " <> Text.pack (show ebsBakerId) <> " was suspended."
+    i18nEvent BakerResumed{..} = "Validator " <> Text.pack (show ebrBakerId) <> " was resumed."
     i18nSpecialEvent BakingRewards{..} =
         "Block rewards\n"
             <> Text.unlines (map (\(addr, amnt) -> "  - account " <> descrAccount addr <> " awarded " <> descrAmount amnt) . Map.toAscList . accountAmounts $ stoBakerRewards)

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -570,10 +570,7 @@ getRewardPeriodLength lfb = do
             case cpksRes of
                 Left err -> return $ StatusOk $ GRPCResponse hds $ Left err
                 Right (EChainParametersAndKeys (ecpParams :: ChainParameters' cpv) _) -> do
-                    let rpLength = case chainParametersVersion @cpv of
-                            SChainParametersV0 -> Nothing
-                            SChainParametersV1 -> Just $ ecpParams ^. cpTimeParameters . supportedOParam . tpRewardPeriodLength
-                            SChainParametersV2 -> Just $ ecpParams ^. cpTimeParameters . supportedOParam . tpRewardPeriodLength
+                    let rpLength = ecpParams ^? cpTimeParameters . traversed . tpRewardPeriodLength
                     return $ StatusOk $ GRPCResponse hds $ Right rpLength
 
 --  |Version of the AccountBalance endpoint.

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.9
+resolver: lts-22.39
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
## Purpose

Update to GHC 9.6.6  (LTS 22.39). Incidentally, add basic support for P8.

## Changes

- Update versions.
- Display validator suspend and resume events.
- Support new chain parameters version.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
