### PR TITLE
Update base to support RFC3339-formatted JSON timestamps. Release 0.33.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,10 @@
 
 ## Unreleased changes
 
+## 0.33.0
+
 - Update GHC version to 9.6.6 (lts-22.39).
+- Support timestamps in scheduled transactions serialized in RFC3339 format in the database.
 
 ## 0.32.1
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.32.1-0
+version:             0.33.0-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Fixes #113

## Changes

- Update base to support RFC3339-formatted JSON serialized timestamps.
- Release version 0.33.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
