### PR TITLE
Support for validator suspension

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 0.34.0
+
 - `/v*/accBalance` endpoints include `isSuspended` flag in the `bakerPoolInfo`.
 - `/v0/bakerPool` endpoint includes `isSuspended`, `isPrimedForSuspension` and `missedRounds`.
 - Add `/v2/accTransactions` endpoint that includes `validatorPrimedForSuspension` and

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+- `/v*/accBalance` endpoints include `isSuspended` flag in the `bakerPoolInfo`.
+- `/v0/bakerPool` endpoint includes `isSuspended`, `isPrimedForSuspension` and `missedRounds`.
+- Add `/v2/accTransactions` endpoint that includes `validatorPrimedForSuspension` and
+  `validatorSuspended` pseudo-transaction types.
+
 ## 0.33.0
 
 - Update GHC version to 9.6.6 (lts-22.39).

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.33.0-0
+version:             0.34.0-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -38,6 +38,7 @@ translation = I18n{..}
     i18nUpdateTransaction UpdateMinBlockTime = "Update minimum block time"
     i18nUpdateTransaction UpdateBlockEnergyLimit = "Update block energy limit"
     i18nUpdateTransaction UpdateFinalizationCommitteeParameters = "Update finalization committee parameters"
+    i18nUpdateTransaction UpdateValidatorScoreParameters = "Update validator score parameters"
 
     i18nRejectReason ModuleNotWF = "Typechecking of module failed"
     i18nRejectReason (ModuleHashAlreadyExists mref) = "A module with the hash " <> descrModule mref <> " already exists"
@@ -184,8 +185,8 @@ translation = I18n{..}
                 DelegateToBaker bid -> "staking pool " <> Text.pack (show bid)
     i18nEvent DelegationAdded{..} = "Added delegator " <> descrDelegator edaDelegatorId edaAccount
     i18nEvent DelegationRemoved{..} = "Removed delegator " <> descrDelegator edrDelegatorId edrAccount
-    i18nEvent BakerSuspended{..} = "Validator " <> Text.pack (show ebsBakerId) <> " was suspended."
-    i18nEvent BakerResumed{..} = "Validator " <> Text.pack (show ebrBakerId) <> " was resumed."
+    i18nEvent BakerSuspended{..} = "Validator " <> descrBaker ebsBakerId ebsAccount <> " was suspended."
+    i18nEvent BakerResumed{..} = "Validator " <> descrBaker ebrBakerId ebrAccount <> " was resumed."
     i18nSpecialEvent BakingRewards{..} =
         "Block rewards\n"
             <> Text.unlines (map (\(addr, amnt) -> "  - account " <> descrAccount addr <> " awarded " <> descrAmount amnt) . Map.toAscList . accountAmounts $ stoBakerRewards)
@@ -247,6 +248,14 @@ translation = I18n{..}
                 ]
       where
         poolName = maybe "passive delegators" (\bid -> "pool with ID " <> descrBakerId bid) stoPoolOwner
+    i18nSpecialEvent ValidatorPrimedForSuspension{..} =
+        "Validator "
+            <> descrBaker vpfsBakerId vpfsAccount
+            <> " was primed for suspension at the next pay day."
+    i18nSpecialEvent ValidatorSuspended{..} =
+        "Validator "
+            <> descrBaker vsBakerId vsAccount
+            <> " was suspended due to inactivity."
 
     i18nSpecialOutcomeShort BakingRewards{} = "Block rewards"
     i18nSpecialOutcomeShort Mint{} = "New CCD minted"
@@ -256,6 +265,8 @@ translation = I18n{..}
     i18nSpecialOutcomeShort PaydayAccountReward{} = "Reward payout"
     i18nSpecialOutcomeShort BlockAccrueReward{} = "Accrual of block rewards"
     i18nSpecialOutcomeShort PaydayPoolReward{} = "Pool rewards"
+    i18nSpecialOutcomeShort ValidatorPrimedForSuspension{} = "Validator primed for suspension"
+    i18nSpecialOutcomeShort ValidatorSuspended{} = "Validator suspended"
 
     i18nErrorMessage (EMErrorResponse NotFound) = "Not found"
     i18nErrorMessage (EMErrorResponse InternalError{}) = "Internal server error"


### PR DESCRIPTION
## Purpose

This adds support for validator suspension as introduced in protocol version 8.

## Changes

- `/v*/accBalance` endpoints include `isSuspended` flag in the `bakerPoolInfo`. This will always be false prior to protocol version 8.
- `/v0/bakerPool` endpoint includes `isSuspended`, `isPrimedForSuspension` and `missedRounds`. (The latter two are under the `currentPaydayStatus`, as they only apply to validators that are in the committee for the current payday.)
- For `v0` and `v1` versions of `accTransactions`, the special transaction outcomes `ValidatorPrimedForSuspension` and `ValidatorSuspended` are omitted. This is for compatibility with wallets that don't support this type.
- For the `v2` version of `accTransactions`, the `ValidatorPrimedForSuspension` and `ValidorSuspended` special outcomes are included, and have the following format:
```json
{
  "blockHash":"684effacf3545ef4cc283280101f98bb3978d07d5f963a99030d28ed1d5478a2",
  "blockTime":1.736251233605e9,
  "details":{
    "description":"Validator primed for suspension",
    "events":["Validator 48XGRnvQoG92T1AwETvW5pnJ1aRSPMKsWtGdKhTqyiNZzMk3Qn (ID 0) was primed for suspension at the next pay day."],
    "outcome":"success",
    "type":"validatorPrimedForSuspension"
  },
  "id":2857155,
  "origin":{"type":"none"},
  "total":"0"
}
```
```json
{
  "blockHash":"684effacf3545ef4cc283280101f98bb3978d07d5f963a99030d28ed1d5478a2",
  "blockTime":1.736251233605e9,
  "details":{
    "description":"Validator suspended",
    "events":["Validator 48XGRnvQoG92T1AwETvW5pnJ1aRSPMKsWtGdKhTqyiNZzMk3Qn (ID 0) was suspended due to inactivity."],
    "outcome":"success",
    "type":"validatorSuspended"
  },
  "id":2857155,
  "origin":{"type":"none"},
  "total":"0"
}
```
- Note: previously special transaction outcomes only included reward-related outcomes, so now filtering out reward transactions has to change to accommodate the new special transaction outcomes.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
