### PR TITLE
Fix JSON serialization of SpecialTransactionOutcome

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased changes
 
+## 0.34.1
+
+- Fix a bug in the deserialization of `SpecialTransactionOutcome` that causes the
+  `/v2/accTransactions` endpoint to fail with `validatorPrimedForSuspension` and
+  `validatorSuspended` events.
+
 ## 0.34.0
 
 - `/v*/accBalance` endpoints include `isSuspended` flag in the `bakerPoolInfo`.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.34.0-0
+version:             0.34.1-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Depends on: https://github.com/Concordium/concordium-client/pull/338 https://github.com/Concordium/concordium-base/pull/593

Fix a bug in the deserialization of `SpecialTransactionOutcome` that causes the  `/v2/accTransactions` endpoint to fail with `validatorPrimedForSuspension` and  `validatorSuspended` events.


## Changes

- Update `concordium-client` dependency. The serialization fix is in `concordium-base`.
- Version to 0.34.1.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
