### PR TITLE
Fix filtering on accTransactions.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+## 0.34.2
+
+- Fix a bug where account transactions where incorrectly excluded from the
+  `/v0/accTransactions` and `/v1/accTransactions` endpoints.
+
 ## 0.34.1
 
 - Fix a bug in the deserialization of `SpecialTransactionOutcome` that causes the

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.34.1-0
+version:             0.34.2-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -1781,9 +1781,11 @@ getAccountTransactionsWorker includeMemos includeSuspensionEvents addrText = do
                 IncludeSuspensionEvents -> const $ return ()
                 ExcludeSuspensionEvents -> \s ->
                     E.where_ $
-                        E.not_ $
-                            (extractedTag s E.==. E.val (Just "ValidatorSuspended"))
-                                E.||. (extractedTag s E.==. E.val (Just "ValidatorPrimedForSuspension"))
+                        E.isNothing (extractedTag s)
+                            E.||. E.not_
+                                ( extractedTag s E.==. E.val (Just "ValidatorSuspended")
+                                    E.||. extractedTag s E.==. E.val (Just "ValidatorPrimedForSuspension")
+                                )
 
         rawReason <- isJust <$> lookupGetParam "includeRawRejectReason"
         case (maybeTimeFromFilter, maybeTimeToFilter, maybeBlockRewardFilter, maybeFinalizationRewardFilter, maybeBakingRewardFilter, maybeEncryptedFilter, maybeTypeFilter) of


### PR DESCRIPTION
## Purpose

Addresses #121

This corrects the filtering that was intended to exclude the `ValidatorSuspended` and `ValidatorPrimedForSuspension` events from the `v0` and `v1` versions of the `accTransactions` endpoint, but also excluded all regular transaction events.

## Changes

- Revise the `WHERE` clause to behave correctly. In particular, allow the case where the tag is `NULL`.
- Bump version.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
