### PR TITLE
Update `transactionCost` to account for setting the suspended status.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add the parameter `suspended` for `/v0/transactionCost?type=configureBaker` to calculate the
+  cost when updated the suspended status of a validator.
+
 ## 0.34.2
 
 - Fix a bug where account transactions where incorrectly excluded from the

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 0.35.0
+
 - Add `isPrimedForSuspension` and `isSuspended` to `accBalance` queries where the account is
   a delegator or validator.
 - Add the parameter `suspended` for `/v0/transactionCost?type=configureBaker` to calculate the

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ The following query parameters are supported
 - `transactionCommission`, whether the transaction fee commission of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
 - `bakerRewardCommission`, whether the baker reward commission of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
 - `finalizationRewardCommission`, whether the finalization reward of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
+- `suspended`, whether the suspended status of the validator is update. Optionally, and only applies when `type` is `configureBaker`.
 - `sender`, only applies when `type` is `update` and is mandatory in this case. Specifies the sender account address of the transaction.
 - `contractIndex`, only applies when `type` is `update` and is mandatory in this case. Specifies the smart contract index of the contract being updated. Given as an integer.
 - `contractSubindex`, only applies when `type` is `update` and is mandatory in this case. Specifies the smart contract subindex of the contract being updated. Given as an integer.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The following query parameters are supported
 - `transactionCommission`, whether the transaction fee commission of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
 - `bakerRewardCommission`, whether the baker reward commission of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
 - `finalizationRewardCommission`, whether the finalization reward of a baker pool is updated. Optionally, and only applies when `type` is either `updateBakerPool` or `configureBaker`.
-- `suspended`, whether the suspended status of the validator is update. Optionally, and only applies when `type` is `configureBaker`.
+- `suspended`, whether the suspended status of the validator is updated. Optionally, and only applies when `type` is `configureBaker`.
 - `sender`, only applies when `type` is `update` and is mandatory in this case. Specifies the sender account address of the transaction.
 - `contractIndex`, only applies when `type` is `update` and is mandatory in this case. Specifies the smart contract index of the contract being updated. Given as an integer.
 - `contractSubindex`, only applies when `type` is `update` and is mandatory in this case. Specifies the smart contract subindex of the contract being updated. Given as an integer.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.34.2-0
+version:             0.35.0-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -833,12 +833,12 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
                             Just ms -> case readMaybe $ Text.unpack ms of
                                 Nothing -> respond400Error (EMParseError "Could not parse `metadataSize` value.") RequestInvalid
                                 Just v -> return $ Just v
-                    let pSize = bakerConfigurePayloadSize True True True True metasize True True True
+                    let pSize = bakerConfigurePayloadSize True True True True metasize True True True False
                     costResponse $ bakerConfigureEnergyCostWithKeys pSize numSignatures
                 "updateBakerStake" -> do
                     isAmountUpdated <- isJust <$> lookupGetParam "amount"
                     isRestakeUpdated <- isJust <$> lookupGetParam "restake"
-                    let pSize = bakerConfigurePayloadSize isAmountUpdated isRestakeUpdated False False Nothing False False False
+                    let pSize = bakerConfigurePayloadSize isAmountUpdated isRestakeUpdated False False Nothing False False False False
                     costResponse $ bakerConfigureEnergyCostWithoutKeys pSize numSignatures
                 "updateBakerPool" -> do
                     metasize <-
@@ -851,7 +851,7 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
                     isTComUpdated <- isJust <$> lookupGetParam "transactionCommission"
                     isBComUpdated <- isJust <$> lookupGetParam "bakerRewardCommission"
                     isFComUpdated <- isJust <$> lookupGetParam "finalizationRewardCommission"
-                    let pSize = bakerConfigurePayloadSize False False isOpenStatusUpdated False metasize isTComUpdated isBComUpdated isFComUpdated
+                    let pSize = bakerConfigurePayloadSize False False isOpenStatusUpdated False metasize isTComUpdated isBComUpdated isFComUpdated False
                     costResponse $ bakerConfigureEnergyCostWithoutKeys pSize numSignatures
                 "update" -> do
                     invoker <-
@@ -938,10 +938,10 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
                                 InvokeContract.Failure{..} -> (False, rcrUsedEnergy)
                     runGRPC getInvokeCost $ costResponseWithIndication . cost
                 "updateBakerKeys" -> do
-                    let pSize = bakerConfigurePayloadSize False False False True Nothing False False False
+                    let pSize = bakerConfigurePayloadSize False False False True Nothing False False False False
                     costResponse $ bakerConfigureEnergyCostWithKeys pSize numSignatures
                 "removeBaker" -> do
-                    let pSize = bakerConfigurePayloadSize True False False False Nothing False False False
+                    let pSize = bakerConfigurePayloadSize True False False False Nothing False False False False
                     costResponse $ bakerConfigureEnergyCostWithoutKeys pSize numSignatures
                 "configureBaker" -> do
                     metasize <-
@@ -957,7 +957,18 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
                     isTComUpdated <- isJust <$> lookupGetParam "transactionCommission"
                     isBComUpdated <- isJust <$> lookupGetParam "bakerRewardCommission"
                     isFComUpdated <- isJust <$> lookupGetParam "finalizationRewardCommission"
-                    let pSize = bakerConfigurePayloadSize isAmountUpdated isRestakeUpdated isOpenStatusUpdated areKeysUpdated metasize isTComUpdated isBComUpdated isFComUpdated
+                    isSuspendedUpdated <- isJust <$> lookupGetParam "suspended"
+                    let pSize =
+                            bakerConfigurePayloadSize
+                                isAmountUpdated
+                                isRestakeUpdated
+                                isOpenStatusUpdated
+                                areKeysUpdated
+                                metasize
+                                isTComUpdated
+                                isBComUpdated
+                                isFComUpdated
+                                isSuspendedUpdated
                     costResponse $
                         (if areKeysUpdated then bakerConfigureEnergyCostWithKeys else bakerConfigureEnergyCostWithoutKeys)
                             pSize


### PR DESCRIPTION
## Purpose

Depends on https://github.com/Concordium/concordium-client/pull/346

Add the parameter `suspended` for `/v0/transactionCost?type=configureBaker` to calculate the cost when updated the suspended status of a validator.

## Changes

- Add the parameter.
- Update the cost calculation appropriately.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
