### PR TITLE
Add endpoint for account transaction as bytes.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           unzip protoc-3.15.3-linux-x86_64.zip
           sudo mv ./bin/protoc /usr/bin/protoc
       - name: Cache cargo and stack dependencies and targets
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add `PUT /v0/transferBytes` endpoint for submitting an account transaction as bytes instead of JSON.
+- Add `PUT /v0/submitRawTransaction` endpoint for submitting an account transaction as bytes instead of JSON.
 
 ## 0.35.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add `PUT /v0/transferBytes` endpoint for submitting an account transaction as bytes instead of JSON.
+
 ## 0.35.0
 
 - Add `isPrimedForSuspension` and `isSuspended` to `accBalance` queries where the account is

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The wallet proxy provides the following endpoints:
   of a transfer or credential deployment
 * `PUT /v0/submitCredential`: deploy a credential/create an account
 * `PUT /v0/submitTransfer`: perform a simple transfer
+* `PUT /v0/submitRawTransaction`: perform a any raw transaction
 * `GET /v0/accTransactions/{account address}`: get the transactions affecting an account
 * `GET /v1/accTransactions/{account address}`: get the transactions affecting an account, including memos
 * `PUT /v0/testnetGTUDrop/{account address}`: request a CCD drop to the specified account
@@ -459,6 +460,14 @@ queried via the `/submissionStatus` endpoint.
 
 When submitting a transfer you should make a PUT request to `/v0/submitTransfer` endpoint.
 The data that should be sent is as the one returned from the library provided as part of the concordium-base repository.
+After submission of the transaction the responses are the same as for the submission of the credential. If successful
+a submission id is returned, which can be used to query the status of the transfer via the `/v0/submissionStatus` endpoint.
+
+
+## Submit raw transaction
+
+When submitting a raw transsaction you should make a PUT request to `/v0/submitRawTransaction` endpoint.
+The data that should be sent is the serialization of the transaction (as a bare block item) as raw bytes.
 After submission of the transaction the responses are the same as for the submission of the credential. If successful
 a submission id is returned, which can be used to query the status of the transfer via the `/v0/submissionStatus` endpoint.
 

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ a submission id is returned, which can be used to query the status of the transf
 
 ## Submit raw transaction
 
-When submitting a raw transsaction you should make a PUT request to `/v0/submitRawTransaction` endpoint.
+When submitting a raw transaction you should make a PUT request to `/v0/submitRawTransaction` endpoint.
 The data that should be sent is the serialization of the transaction (as a bare block item) as raw bytes.
 After submission of the transaction the responses are the same as for the submission of the credential. If successful
 a submission id is returned, which can be used to query the status of the transfer via the `/v0/submissionStatus` endpoint.

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -37,8 +37,9 @@ import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Parser (json')
 import Data.Aeson.Types (Pair, parse)
-import Data.Conduit (connect)
+import Data.Conduit (connect, runConduit, (.|))
 import Data.Conduit.Attoparsec (sinkParserEither)
+import Data.Conduit.Binary (sinkLbs)
 import Data.Foldable
 import Data.Functor
 import qualified Data.Map.Strict as Map
@@ -257,6 +258,7 @@ mkYesod
 /v0/submitCredential/ CredentialR PUT
 /v0/submitTransfer/ TransferR PUT
 /v0/testnetGTUDrop/#Text GTUDropR PUT
+/v0/submitTransferBytes/ TransferBytesR PUT
 /v0/global GlobalFileR GET
 /v0/health HealthR GET
 /v0/ip_info IpsR GET
@@ -1082,6 +1084,20 @@ putTransferR =
                 case S.decode (S.encode sig <> body) of
                     Left err -> fail err
                     Right tx -> return tx
+
+putTransferBytesR :: Handler TypedContent
+putTransferBytesR = do
+    binData <- runConduit $ rawRequestBody .| sinkLbs
+    case S.decodeLazy binData of
+        Left err -> respond400Error (EMParseError err) RequestInvalid
+        Right tx -> do
+            runGRPC (doSendBlockItem (NormalTransaction tx)) $ \case
+                False -> do
+                    -- transaction invalid
+                    $(logError) "Transaction rejected by the node."
+                    respond400Error EMTransactionRejected RequestInvalid
+                True ->
+                    sendResponse (object ["submissionId" .= (getHash (NormalTransaction tx) :: TransactionHash)])
 
 -- | An error that is the result of converting a transaction status to a "simple"
 --  transaction status.


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-wallet-proxy/issues/126.

## Changes

- `PUT v0/submitRawTransaction` endpoint added for submitting an account transaction as bytes instead of JSON.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

