### PR TITLE
AccTransaction v3 includes plt events

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Add endpoint `GET /v3/accTransactions/{account address}` get the transactions affecting an account's ccd or plt balances (including special transaction outcomes for suspended/inactive validators and including CCD transactions with memos).
 - Add endpoint `GET /v2/accBalance/{account address}` that includes the plt (protocol level token) balances of an account.
 - Add endpoint `GET /v0/plt/tokens` to get a list of all plt token infos.
 - Add endpoint `GET /v0/plt/tokenInfo/{tokenId}` to get the token info about a given plt token and its module state (with metadata url)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ cooldowns and the available balance) and get the info if an account is on any al
 * `PUT /v0/submitTransfer`: perform a simple transfer
 * `PUT /v0/submitRawTransaction`: perform a any raw transaction
 * `GET /v0/accTransactions/{account address}`: get the transactions affecting an account's ccd balance
-* `GET /v1/accTransactions/{account address}`: get the transactions affecting an account's ccd balance (including transactions with memos)
+* `GET /v1/accTransactions/{account address}`: get the transactions affecting an account's ccd balance (including CCD transactions with memos)
+* `GET /v2/accTransactions/{account address}`: get the transactions affecting an account's ccd balance (including special transaction outcomes for suspended/inactive validators and including CCD transactions with memos)
+* `GET /v3/accTransactions/{account address}`: get the transactions affecting an account's ccd or plt balances (including special transaction outcomes for suspended/inactive validators and including CCD transactions with memos)
 * `PUT /v0/testnetGTUDrop/{account address}`: request a CCD drop to the specified account
 * `GET /v0/health`: get a response specifying if the wallet proxy is up to date
 * `GET /v0/global`: get the cryptographic parameters obtained from the node it is connected to
@@ -575,10 +577,12 @@ a submission id is returned, which can be used to query the status of the transf
 ## Get transactions
 
 The endpoint `/accTransactions/{account address}` retrieves a partial list of transactions affecting an account.
-There are three versions of the endpoint, `v0`, `v1` and `v2`.
-Version `v0` treats transactions with memos as the equivalent transaction without a memo.
+There are four versions of the endpoint, `v0`, `v1`, `v2` and `v3`.
+Version `v0` treats CCD transactions with memos as the equivalent transaction without a memo.
 Versions `v0` and `v1` exclude the special transaction outcomes for suspending inactive validators,
-which are included in `v2`.
+which are included in `v2` and `v3`.
+
+Versions `v3` includes in addition transactions affecting an account's plt balance.
 
 They support the following parameters.
 - `order`: whether to order the transactions in ascending or descending order of occurrence. A value beginning with `d` or `D` is interpreted as descending; any other (or no) value is interpreted as ascending.
@@ -675,7 +679,7 @@ This is only present if the origin type is `"self"` (since otherwise the account
 When present, this is always a positive value.
 
 #### `total` (required)
-The total change in the account's __public__ balance due to the transaction and associated fees.
+The total change in the account's __public__ CCD balance due to the transaction and associated fees.
 A negative value indicates a debit from the account, while a positive value indicates a credit to the account.
 
 #### `energy` (optional)
@@ -723,6 +727,10 @@ It consists of the following fields:
   - in the `v2` endpoint `type` can additionaly be one of
     - `"validatorPrimedForSuspension"`
     - `"validatorSuspended"`
+  - in the `v3` endpoint `type` can additionaly be one of
+      - `"updateCreatePLT"`
+      - `"tokenGovernance"`
+      - `"tokenHolder"`
 - `description` (required): a brief localized description of the type of the transaction
 - `outcome` (required):
   - `"success"` if the transaction was executed successfully

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -196,10 +196,10 @@ translation = I18n{..}
     i18nEvent BakerSuspended{..} = "Validator " <> descrBaker ebsBakerId ebsAccount <> " was suspended."
     i18nEvent BakerResumed{..} = "Validator " <> descrBaker ebrBakerId ebrAccount <> " was resumed."
     i18nEvent (TokenModuleEvent tokenId type' _) = Text.pack (show tokenId) <> " token module event occurred of type " <> Text.pack (show type') <> "." -- TODO: It would be ideally to render the `details` in a readable way in the wallets.
-    i18nEvent (TokenTransfer tokenId from to amount _) = Text.pack (show amount) <> " " <> Text.pack (show tokenId) <> "%s %s transferred from " <> Text.pack (show from) <> " to " <> Text.pack (show to) <> "." -- TODO: It would be ideally to render the `memo` in a readable way in the wallets.
+    i18nEvent (TokenTransfer tokenId from to amount memo) = Text.pack (tokenAmountToString amount) <> " " <> Text.pack (show tokenId) <> " transferred from " <> Text.pack (show from) <> " to " <> Text.pack (show to) <> maybe "" (\m -> " with memo " <> Text.pack (show m)) memo <> "." -- TODO: It would be ideally to render the `memo` in a readable way in the wallets.
     i18nEvent TokenMint{..} = Text.pack (tokenAmountToString etmAmount) <> " " <> Text.pack (show etmTokenId) <> " minted to " <> Text.pack (show etmTarget)
     i18nEvent TokenBurn{..} = Text.pack (tokenAmountToString etbAmount) <> " " <> Text.pack (show etbTokenId) <> " burned from " <> Text.pack (show etbTarget)
-    i18nEvent TokenCreated{..} = "Token created:" <> Text.pack (showPrettyJSON etcPayload)
+    i18nEvent TokenCreated{..} = "Token created: " <> Text.pack (showPrettyJSON etcPayload)
     i18nSpecialEvent BakingRewards{..} =
         "Block rewards\n"
             <> Text.unlines (map (\(addr, amnt) -> "  - account " <> descrAccount addr <> " awarded " <> descrAmount amnt) . Map.toAscList . accountAmounts $ stoBakerRewards)


### PR DESCRIPTION
## Purpose


## Changes

- Add endpoint `GET /v3/accTransactions/{account address}` get the transactions affecting an account's ccd or plt balances (including special transaction outcomes for suspended/inactive validators and including CCD transactions with memos).
