### PR TITLE
Update GHC to 9.10.2 (LTS 24.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   RUST: 1.82
-  GHC: 9.6.6
+  GHC: 9.8.4
 
 jobs:
   fourmolu:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,9 @@ jobs:
     - name: Download fourmolu
       uses: supplypike/setup-bin@v1
       with:
-        uri: 'https://github.com/fourmolu/fourmolu/releases/download/v0.13.1.0/fourmolu-0.13.1.0-linux-x86_64'
+        uri: 'https://github.com/fourmolu/fourmolu/releases/download/v0.18.0.0/fourmolu-0.18.0.0-linux-x86_64'
         name: 'fourmolu'
-        version: '0.13.1.0'
+        version: '0.18.0.0'
 
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   RUST: 1.82
-  GHC: 9.8.4
+  GHC: 9.10.2
 
 jobs:
   fourmolu:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: wallet-proxy
   # the build image
-  BASE_IMAGE_TAG: rust-1.82_ghc-9.8.4
+  BASE_IMAGE_TAG: rust-1.82_ghc-9.10.2-1
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: wallet-proxy
   # the build image
-  BASE_IMAGE_TAG: rust-1.82_ghc-9.6.6-2
+  BASE_IMAGE_TAG: rust-1.82_ghc-9.8.4
 
 jobs:
   build-and-push-image:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Bump GHC version to 9.8.4 (lts-23.27).
+
 ## [0.38.0] - 2025-06-30
 
 - Rejected PLT txs are parsed in the `GET /v3/accTransactions/{account address}` response.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Bump GHC version to 9.8.4 (lts-23.27).
+- Bump GHC version to 9.10.2 (lts-24.0).
 
 ## [0.38.0] - 2025-06-30
 

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/Conc
 
 dependencies:
 - aeson >= 1.4.2
+- attoparsec-aeson
 - base >=4.7 && < 5
 - base16-bytestring >= 0.1.1.6
 - bytestring >= 0.10

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -344,7 +344,7 @@ parseSetCookie' c =
         let (x, y) = BS.break (== w) s
         in  (x, BS.drop 1 y)
     pairs = map (parsePair . dropSpace) $ BS.split 59 c ++ [BS8.empty] -- 59 = semicolon
-    flags = map (first (BS8.map CH.toLower)) $ tail pairs
+    flags = map (first (BS8.map CH.toLower)) $ drop 1 pairs
     parsePair = breakDiscard 61 -- equals sign
     dropSpace = BS.dropWhile (== 32) -- space
 
@@ -547,7 +547,7 @@ firstPaydayAfter nextPayday epochDuration (RewardPeriodLength ep) cooldownEnd =
                 mult :: Word = ceiling (timeDiff / paydayLength)
             in  Clock.addUTCTime (fromIntegral mult * paydayLength) nextPayday
 
-pendingChangeToJSON :: (AE.KeyValue kv) => Maybe UTCTime -> Duration -> Maybe RewardPeriodLength -> StakePendingChange' UTCTime -> [kv]
+pendingChangeToJSON :: (AE.KeyValue e kv) => Maybe UTCTime -> Duration -> Maybe RewardPeriodLength -> StakePendingChange' UTCTime -> [kv]
 pendingChangeToJSON _ _ _ NoChange = []
 pendingChangeToJSON mnextPaydayTime epochDuration mrewardEpochs (ReduceStake amt eff) =
     [ "pendingChange"

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.39
+resolver: lts-23.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -45,7 +45,9 @@ packages:
 # extra-deps: []
 
 extra-deps:
-
+- network-control-0.0.2
+- http2-5.0.1
+- tls-1.8.0
 - github: Concordium/http2-client
   commit: af0edc5fba5265ba9a4b2f91cfc3c466e4c82197
 
@@ -56,9 +58,10 @@ extra-deps:
     - http2-grpc-proto-lens
     - http2-grpc-types
 
-- proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
-- proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
-- ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
+# We allow newer versions of dependencies because we use
+# old versions of http2-client and http2-grpc-haskell, which
+# have not been updated.
+allow-newer: true
 
 extra-lib-dirs:
 - ./deps/concordium-client/deps/concordium-base/lib

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-23.27
+resolver: lts-24.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
## Purpose

Part of [COR-1558](https://linear.app/concordium/issue/COR-1558/upgrade-haskell-ghc-to-=-967)

Update to LTS 24.0, GHC 9.10.2

## Changes

- Bump the LTS version
- Bump the GHC version
- Bump the stack version to 3.7.1
- Bump the fourmolu version to 0.18.0.0
- Bump the base image tag to rust-1.82_ghc-9.10.2-1
- Remove some pinned dependencies that are now available in the LTS snapshot
- Pin older versions of http2, network-control and tls as the http2-client-grpc related dependencies don't work with them.
- `allow-newer` versions of Haskell packages, to avoid having to update the forked libraries just to widen the version constraints.
- Minor fixes

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
