### PR TITLE
Update the base build image

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -14,7 +14,7 @@ env:
   REGISTRY: docker.io
   IMAGE_NAME: wallet-proxy
   # the build image
-  BASE_IMAGE_TAG: rust-1.82_ghc-9.10.2-1
+  BASE_IMAGE_TAG: rust-1.82_ghc-9.10.2-2
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
## Purpose

Closes [COR-1660](https://github.com/Concordium/concordium-infra-images/pull/34)

Update the base docker image to the debian:bullseye version, which has a more recent PostgreSQL version that's required for LTS 24.0.
