### PR TITLE
Fix parsing tokenId

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Fix parsing of the `tokenId` query parameter to work without quotes in the url when using the `GET /v0/transactionCost` endpoint in a `tokenUpdate` transaction type.
 - Bump GHC version to 9.10.2 (lts-24.0).
 
 ## [0.40.0] - 2025-07-22

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -929,9 +929,7 @@ getTransactionCostR = withExchangeRate $ \(rate, pv) -> do
                     tokenId <-
                         lookupGetParam "tokenId" >>= \case
                             Nothing -> respond400Error (EMParseError "Missing `tokenId` value.") RequestInvalid
-                            Just a -> case readMaybe $ Text.unpack a of
-                                Nothing -> respond400Error (EMParseError "Could not parse `tokenId` value.") RequestInvalid
-                                Just b -> return b
+                            Just tokenId -> return tokenId
 
                     let tokenParameterSize =
                             -- 4 bytes for length of parameter.


### PR DESCRIPTION
## Purpose

Remove the need for quotes around the `tokenId` query parameter.

Before the fix:
```
curl "http://localhost:3005/v0/transactionCost?type=tokenUpdate&tokenId=\"TestInitialSupply\"&listOperationsSize=300&tokenOperationTypeCount=%7B%22transfer%22%3A3%7D"
```

After the fix:

```
curl "http://localhost:3005/v0/transactionCost?type=tokenUpdate&tokenId=TestInitialSupply&listOperationsSize=300&tokenOperationTypeCount=%7B%22transfer%22%3A3%7D"
```
