### PR TITLE
Changing the LocalTokenId usage instead of TokenId

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog for wallet-proxy
 
 ## [0.41.1] - 2025-08-28
-- Changed the query parameter type of the `parseCIS2TokenIds` endpoint from `LocalTokenId` to `TokenId`. The `TokenId` type is related to PLT tokens, whereas the `LocalTokenId` type is related to CIS2 tokens.
+- Fixed a bug where CIS2 endpoints would fail to parse token IDs correctly, due to parsing them as PLT Token IDs.
 
 ## [0.41.0] - 2025-08-05
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for wallet-proxy
 
+## [0.41.1] - 2025-08-28
+- Changed the query parameter type of the `parseCIS2TokenIds` endpoint from `LocalTokenId` to `TokenId`. The `TokenId` type is related to PLT tokens, whereas the `LocalTokenId` type is related to CIS2 tokens.
+
 ## [0.41.0] - 2025-08-05
 
 - Fix parsing of the `tokenId` query parameter to work without quotes in the url when using the `GET /v0/transactionCost` endpoint in a `tokenUpdate` transaction type.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.41.0-3
+version:             0.41.1-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -129,22 +129,22 @@ instance (S.Serialize a) => PersistField (ByteStringSerialized a) where
 instance (S.Serialize a) => PersistFieldSql (ByteStringSerialized a) where
     sqlType _ = sqlType (Proxy.Proxy :: Proxy.Proxy BS.ByteString)
 
-newtype LocalTokenId = LocalTokenId {unTokenId :: BSS.ShortByteString}
+newtype CIS2TokenId = CIS2TokenId {unTokenId :: BSS.ShortByteString}
     deriving (Eq, Show)
     deriving (AE.ToJSON, AE.FromJSON) via ShortByteStringHex
 
-instance PersistField LocalTokenId where
+instance PersistField CIS2TokenId where
     toPersistValue = toPersistValue . BSS.fromShort . unTokenId
-    fromPersistValue = fmap (LocalTokenId . BSS.toShort) . fromPersistValue
+    fromPersistValue = fmap (CIS2TokenId . BSS.toShort) . fromPersistValue
 
-instance PersistFieldSql LocalTokenId where
+instance PersistFieldSql CIS2TokenId where
     sqlType _ = sqlType (Proxy.Proxy :: Proxy.Proxy BS.ByteString)
 
-instance S.Serialize LocalTokenId where
-    put (LocalTokenId tid) = S.putWord8 (fromIntegral (BSS.length tid)) <> S.putShortByteString tid
+instance S.Serialize CIS2TokenId where
+    put (CIS2TokenId tid) = S.putWord8 (fromIntegral (BSS.length tid)) <> S.putShortByteString tid
     get = do
         len <- S.getWord8
-        LocalTokenId <$> S.getShortByteString (fromIntegral len)
+        CIS2TokenId <$> S.getShortByteString (fromIntegral len)
 
 -- | Create the database schema and types. This creates a type called @Summary@
 --  with fields @summaryBlock@, @summaryTimestamp@, etc., with stated types.
@@ -175,7 +175,7 @@ share
   CIS2Entry sql=cis2_tokens
     index ContractIndex
     subindex ContractSubindex
-    token_id LocalTokenId
+    token_id CIS2TokenId
     total_supply (Ratio Integer)
   |]
 
@@ -1559,7 +1559,7 @@ getCIS2Tokens index subindex = do
 -- | Lookup token ids from the tokenId query parameter, and attempt to parse
 --  them as a comma-separated list. Responds with an invalid request error
 --  in case parsing is unsuccessful.
-parseCIS2TokenIds :: Handler [TokenId]
+parseCIS2TokenIds :: Handler [CIS2TokenId]
 parseCIS2TokenIds = do
     param <-
         lookupGetParam "tokenId" >>= \case
@@ -1624,6 +1624,7 @@ getCIS2TokenMetadataV1 index subindex = do
         let serializedParam = Wasm.Parameter . BSS.toShort . S.runPut $ do
                 S.putWord16le 1
                 S.put tid
+
         cis2InvokeHelperError lf contractAddr iInfo (Wasm.EntrypointName "tokenMetadata") serializedParam nrg $
             \case
                 (_, InvokeContract.Success{..})
@@ -1636,6 +1637,7 @@ getCIS2TokenMetadataV1 index subindex = do
                                   "metadataChecksum" .= muChecksum md
                                 ]
                 (_, _notSuccess) -> return Nothing
+
     sendResponse $
         object
             [ "contractName" .= (Wasm.initContractName (Wasm.iiName iInfo)),


### PR DESCRIPTION
Jira-Id: COR-1694

## Purpose

This is to fix a bug reported as per COR-1694, during a call to the endpoint in wallet-proxy https://wallet-proxy.devnet-plt-beta.concordium.com/v1/CIS2TokenMetadata/0/0?tokenId=00%2C01, the metadata returned was empty.

## Changes

It appears the bug was caused by the usage of the wrong TokenId type. It should be LocalTokenId which is for CIS2

## Checklist

- [ X ] My code follows the style of this project.
- [ X ] The code compiles without warnings.
- [ X ] I have performed a self-review of the changes.
- [ X ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [  X ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ X ] I accept the above linked CLA.
