### PR TITLE
fix: public key now passed as a normal text parameter, decoded into verify key

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Updated endpoint `/v0/accountsByPublicKey/ AccountsByPublicKey GET` to require no quotes around the public key parameter.
+
 ## [0.41.2-0] - 2025-09-30
 
 - Added endpoint `/v0/accountsByPublicKey/ AccountsByPublicKey GET` for querying accounts by public key.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- Updated endpoint `/v0/accountsByPublicKey/ AccountsByPublicKey GET` to require no quotes around the public key parameter.
+- Changed endpoint route from `/v0/accountsByPublicKey/ AccountsByPublicKey GET` to `/v0/keyAccounts/#Text KeyAccounts GET`. Now the public key is provided as a path parameter and the filter is changed to `onlySimple` to retrieve only the simple accounts: where `?onlySimple=y` returns only simple accounts and when `?onlySimple=n` or is not provided then all accounts will be returned matching the public key.
 
 ## [0.41.2-0] - 2025-09-30
 

--- a/README.md
+++ b/README.md
@@ -1388,10 +1388,18 @@ Example response:
 
 ## Accounts by public key
 
-A GET request to `/v0/accountsByPublicKey` returns accounts associated to a
-given public key. The public key is specified in the GET parameter `publicKey`.
-The result can be filtered by simple accounts via the GET parameter
-`filterSimple`.
+A GET request to `/v0/keyAccounts/{publicKey}` returns accounts associated to a given public key. 
+
+There is an Optional path variable - which allows the caller to get "only simple" accounts associated to the provided public key
+`?onlySimple=y`. If this parameter is not provided or is set to `?onlySimple=n` then all of the accounts are returned.
+
+Example request for only simple accounts:
+
+`/v0/keyAccounts/bef37420b5d3a9de90abe87da23d5e109599d5778ca572249176846a26c66395?onlySimple=y`
+
+Example request for all accounts:
+
+`/v0/keyAccounts/bef37420b5d3a9de90abe87da23d5e109599d5778ca572249176846a26c66395`
 
 Example response:
 

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -627,10 +627,11 @@ getKeyAccounts keyText = do
 
     -- optional param where 'y' only the accounts that are simple will be returned, if 'n' or not provided, all accounts for the public key will be returned
     onlySimpleParam <- lookupGetParam "onlySimple"
-    let onlySimple :: Maybe Bool
-        onlySimple = case fmap Text.toLower onlySimpleParam of
-            Just t | t == "y" -> Just True
-            _ -> Nothing
+    onlySimple <- case fmap Text.toLower onlySimpleParam of
+        Just "y" -> return True
+        Just "n" -> return False
+        Just other -> respond400Error (EMParseError $ "Invalid `onlySimple` parameter (should be `y` or `n`): " <> other)
+        Nothing -> return False
 
     queryResult :: [Entity AccountPublicKeyBinding] <- runDB $ do
         E.select $ E.from $ \apkb -> do

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -110,12 +110,12 @@ import Concordium.Client.Types.Transaction (
  )
 import Concordium.Common.Version
 import Concordium.Crypto.ByteStringHelpers (ShortByteStringHex (..))
+import Concordium.Crypto.Ed25519Signature as Ed25519
 import Concordium.Crypto.SHA256 (Hash)
 import Concordium.Crypto.SignatureScheme (KeyPair, VerifyKey (..))
-import qualified Concordium.Crypto.Ed25519Signature as Ed25519
 import Concordium.ID.Types (CredentialIndex (..), KeyIndex (..), addressFromText)
-import qualified Logging
 import qualified Data.Serialize as Cereal
+import qualified Logging
 
 import Internationalization
 

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -617,7 +617,6 @@ getRewardPeriodLength lfb = do
 --             'n' (or omitted) means all accounts are returned.
 --
 -- Example: ?onlySimple=y
---
 getKeyAccounts :: Text -> Handler TypedContent
 getKeyAccounts keyText = do
     -- Parse the public key from the URL parameter
@@ -631,7 +630,7 @@ getKeyAccounts keyText = do
     let onlySimple :: Maybe Bool
         onlySimple = case fmap Text.toLower onlySimpleParam of
             Just t | t == "y" -> Just True
-            _                 -> Nothing
+            _ -> Nothing
 
     queryResult :: [Entity AccountPublicKeyBinding] <- runDB $ do
         E.select $ E.from $ \apkb -> do

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -110,7 +110,7 @@ import Concordium.Client.Types.Transaction (
  )
 import Concordium.Common.Version
 import Concordium.Crypto.ByteStringHelpers (ShortByteStringHex (..))
-import Concordium.Crypto.Ed25519Signature as Ed25519
+import qualified Concordium.Crypto.Ed25519Signature as Ed25519
 import Concordium.Crypto.SHA256 (Hash)
 import Concordium.Crypto.SignatureScheme (KeyPair, VerifyKey (..))
 import Concordium.ID.Types (CredentialIndex (..), KeyIndex (..), addressFromText)


### PR DESCRIPTION

## Purpose

require no json quotes string around the public key when calling the endpoint to getAccountsByPublicKey

## Changes

Decode the utf8 text of the hex string, then decode using Cereal to create an instance of VerifyKeyEd25519

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

