### PR TITLE
fix: bump wallet proxy version for release of changed endpoint from accountsByPublicKey to keyAccounts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+## [0.41.3-0] - 2025-10-02
+
 - Changed endpoint route from `/v0/accountsByPublicKey/ AccountsByPublicKey GET` to `/v0/keyAccounts/#Text KeyAccounts GET`. Now the public key is provided as a path parameter and the filter is changed to `onlySimple` to retrieve only the simple accounts: where `?onlySimple=y` returns only simple accounts and when `?onlySimple=n` or is not provided then all accounts will be returned matching the public key.
 
 ## [0.41.2-0] - 2025-09-30

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wallet-proxy
-version:             0.41.2-0
+version:             0.41.3-0
 github:              "Concordium/concordium-wallet-proxy"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION

## Purpose

bump wallet proxy version for release of changed endpoint from accountsByPublicKey to keyAccounts

## Changes

bump version and update changelog

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

