### PR TITLE
Add support for meta update transactions + lock ops

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- Add support for PLT lock meta-update transaction summaries in account history.
+- Decode and render `metaUpdate` account transactions with `LockCreated` and `LockDestroyed` events.
+- Preserve `fromLock` and `toLock` metadata for PLT token transfers in `v3/accTransactions`.
+
 ## [0.48.0] - 2026-04-14
 
 - Add support for new RBAC token operation types `assignAdminRoles`, `revokeAdminRoles` and `updateMetadata` in `v0/transactionCost`.

--- a/src/Internationalization/En.hs
+++ b/src/Internationalization/En.hs
@@ -98,6 +98,14 @@ translation = I18n{..}
     i18nRejectReason InsufficientDelegationStake = "Adding a delegator with 0 stake is not allowed."
     i18nRejectReason (NonExistentTokenId tokenId) = "Non existing plt token id " <> Text.pack (show tokenId) <> "."
     i18nRejectReason (TokenUpdateTransactionFailed reason) = "Token update transaction failed with reason: " <> Text.pack (show reason) <> "."
+    i18nRejectReason (NonExistentLockId lockId) = "Non existing lock id " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockExpired lockId) = "Lock " <> Text.pack (show lockId) <> " has expired."
+    i18nRejectReason (LockFundNotAuthorized lockId account) = "Account " <> descrAccount account <> " is not authorized to fund lock " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockSendNotAuthorized lockId account) = "Account " <> descrAccount account <> " is not authorized to send from lock " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockReturnNotAuthorized lockId account) = "Account " <> descrAccount account <> " is not authorized to return from lock " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockCancelNotAuthorized lockId account) = "Account " <> descrAccount account <> " is not authorized to cancel lock " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockTokenNotPermitted lockId tokenId) = "Token " <> Text.pack (show tokenId) <> " is not permitted by lock " <> Text.pack (show lockId) <> "."
+    i18nRejectReason (LockRecipientNotPermitted lockId account) = "Account " <> descrAccount account <> " is not a permitted recipient for lock " <> Text.pack (show lockId) <> "."
 
     i18nTransactionType TTDeployModule = "Deploy module"
     i18nTransactionType TTInitContract = "Initialize smart contract"
@@ -121,6 +129,7 @@ translation = I18n{..}
     i18nTransactionType TTConfigureBaker = "Configure validator"
     i18nTransactionType TTConfigureDelegation = "Configure delegation"
     i18nTransactionType TTTokenUpdate = "Token update"
+    i18nTransactionType TTMetaUpdate = "Meta update"
 
     i18nDeployCredential Initial = "Deploy initial account credential"
     i18nDeployCredential Normal = "Deploy account credential"
@@ -193,10 +202,12 @@ translation = I18n{..}
     i18nSupplementedEvent BakerSuspended{..} = "Validator " <> descrBaker ebsBakerId ebsAccount <> " was suspended."
     i18nSupplementedEvent BakerResumed{..} = "Validator " <> descrBaker ebrBakerId ebrAccount <> " was resumed."
     i18nSupplementedEvent (TokenModuleEvent tokenId type' _) = Text.pack (show tokenId) <> " token module event occurred of type " <> Text.pack (show type') <> "." -- TODO: It would be ideally to render the `details` in a readable way in the wallets.
-    i18nSupplementedEvent (TokenTransfer tokenId from to amount memo) = Text.pack (tokenAmountToString amount) <> " " <> Text.pack (show tokenId) <> " transferred from " <> Text.pack (show from) <> " to " <> Text.pack (show to) <> maybe "" (\m -> " with memo " <> Text.pack (show m)) memo <> "." -- TODO: It would be ideally to render the `memo` in a readable way in the wallets.
+    i18nSupplementedEvent TokenTransfer{..} = Text.pack (tokenAmountToString ettAmount) <> " " <> Text.pack (show ettTokenId) <> " transferred from " <> Text.pack (show ettFrom) <> maybe "" (\lockId -> " locked by " <> Text.pack (show lockId)) ettFromLock <> " to " <> Text.pack (show ettTo) <> maybe "" (\lockId -> " locked by " <> Text.pack (show lockId)) ettToLock <> maybe "" (\m -> " with memo " <> Text.pack (show m)) ettMemo <> "." -- TODO: It would be ideally to render the `memo` in a readable way in the wallets.
     i18nSupplementedEvent TokenMint{..} = Text.pack (tokenAmountToString etmAmount) <> " " <> Text.pack (show etmTokenId) <> " minted to " <> Text.pack (show etmTarget) <> "."
     i18nSupplementedEvent TokenBurn{..} = Text.pack (tokenAmountToString etbAmount) <> " " <> Text.pack (show etbTokenId) <> " burned from " <> Text.pack (show etbTarget) <> "."
     i18nSupplementedEvent TokenCreated{..} = "Token created: " <> Text.pack (showPrettyJSON etcPayload)
+    i18nSupplementedEvent LockCreated{..} = "Lock created: " <> Text.pack (show elcLockId) <> "."
+    i18nSupplementedEvent LockDestroyed{..} = "Lock destroyed: " <> Text.pack (show eldLockId) <> "."
     i18nSpecialEvent BakingRewards{..} =
         "Block rewards\n"
             <> Text.unlines (map (\(addr, amnt) -> "  - account " <> descrAccount addr <> " awarded " <> descrAmount amnt) . Map.toAscList . accountAmounts $ stoBakerRewards)

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -1506,8 +1506,36 @@ getSimpleTransactionStatus i trHash = do
                                     "tokenId" .= ettTokenId,
                                     "tokenAmount" .= ettAmount
                                   ]
+                                    ++ ["fromLock" AE..= lockId | lockId <- toList ettFromLock]
+                                    ++ ["toLock" AE..= lockId | lockId <- toList ettToLock]
                                     ++ ["memo" AE..= memo | memo <- toList ettMemo]
                                 )
+                        TxSuccess _ -> return []
+                        TxReject reason -> return ["outcome" .= String "reject", "rejectReason" .= i18n i reason]
+                TSTAccountTransaction (Just TTMetaUpdate) ->
+                    case stsResult of
+                        TxSuccess [TokenTransfer{ettTo = HolderAccount{haAccount = transferDestination}, ..}] ->
+                            return
+                                ( [ "outcome" .= String "success",
+                                    "to" .= transferDestination,
+                                    "tokenId" .= ettTokenId,
+                                    "tokenAmount" .= ettAmount
+                                  ]
+                                    ++ ["fromLock" AE..= lockId | lockId <- toList ettFromLock]
+                                    ++ ["toLock" AE..= lockId | lockId <- toList ettToLock]
+                                    ++ ["memo" AE..= memo | memo <- toList ettMemo]
+                                )
+                        TxSuccess [LockCreated{..}] ->
+                            return
+                                [ "outcome" .= String "success",
+                                  "lockId" .= elcLockId,
+                                  "lockConfig" .= elcLockConfig
+                                ]
+                        TxSuccess [LockDestroyed{..}] ->
+                            return
+                                [ "outcome" .= String "success",
+                                  "lockId" .= eldLockId
+                                ]
                         TxSuccess _ -> return []
                         TxReject reason -> return ["outcome" .= String "reject", "rejectReason" .= i18n i reason]
                 TSTAccountTransaction (Just TTRegisterData) ->
@@ -2150,6 +2178,7 @@ getAccountTransactionsWorker includeMemos includeSuspensionEvents includePltEven
                                 E.||. E.not_
                                     ( extractedType E.==. E.val (Just "updateCreatePLT")
                                         E.||. extractedType E.==. E.val (Just "tokenUpdate")
+                                        E.||. extractedType E.==. E.val (Just "metaUpdate")
                                     )
 
         rawReason <- isJust <$> lookupGetParam "includeRawRejectReason"
@@ -2457,7 +2486,24 @@ formatEntry includeMemos rawRejectReason i self (Entity key Entry{}, Entity _ Su
                                       "tokenId" .= ettTokenId,
                                       "tokenTransferAmount" .= ettAmount
                                     ]
+                                        ++ ["fromLock" AE..= lockId | lockId <- toList ettFromLock]
+                                        ++ ["toLock" AE..= lockId | lockId <- toList ettToLock]
                                         ++ ["memo" AE..= memo | memo <- toList ettMemo]
+                                (TSTAccountTransaction (Just TTMetaUpdate), [TokenTransfer{ettFrom = HolderAccount{haAccount = transferSource}, ettTo = HolderAccount{haAccount = transferDestination}, ..}]) ->
+                                    [ "transferSource" .= transferSource,
+                                      "transferDestination" .= transferDestination,
+                                      "tokenId" .= ettTokenId,
+                                      "tokenTransferAmount" .= ettAmount
+                                    ]
+                                        ++ ["fromLock" AE..= lockId | lockId <- toList ettFromLock]
+                                        ++ ["toLock" AE..= lockId | lockId <- toList ettToLock]
+                                        ++ ["memo" AE..= memo | memo <- toList ettMemo]
+                                (TSTAccountTransaction (Just TTMetaUpdate), [LockCreated{..}]) ->
+                                    [ "lockId" .= elcLockId,
+                                      "lockConfig" .= elcLockConfig
+                                    ]
+                                (TSTAccountTransaction (Just TTMetaUpdate), [LockDestroyed{..}]) ->
+                                    ["lockId" .= eldLockId]
                                 _ -> [],
                           eventSubtotal self evts
                         )
@@ -2567,6 +2613,7 @@ renderTransactionType TTRegisterData = "registerData"
 renderTransactionType TTConfigureBaker = "configureBaker"
 renderTransactionType TTConfigureDelegation = "configureDelegation"
 renderTransactionType TTTokenUpdate = "tokenUpdate"
+renderTransactionType TTMetaUpdate = "metaUpdate"
 
 renderTransactionSummaryType :: TransactionSummaryType -> Text
 renderTransactionSummaryType (TSTAccountTransaction (Just tt)) = renderTransactionType tt

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,86 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+import qualified Data.Aeson as AE
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.FixedByteString as FBS
+import Data.Word (Word64)
+
+import Concordium.Common.Amount
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Types
+import Concordium.Types.Execution
+import Concordium.Types.Queries
+import Concordium.Types.Tokens
+
+account :: Word -> AccountAddress
+account n = AccountAddress $ FBS.pack $ replicate 32 (fromIntegral n)
+
+lock :: Word64 -> LockId
+lock n =
+    LockId
+        { liAccountIndex = n,
+          liSequenceNumber = n + 1,
+          liCreationOrder = n + 2
+        }
+
+summary :: [SupplementedEvent] -> SupplementedTransactionSummary
+summary events =
+    SupplementedTransactionSummary
+        { stsSender = Just (account 1),
+          stsHash = TransactionHashV0 $ Hash.hash (BS.pack [1, 2, 3]),
+          stsCost = Amount 0,
+          stsEnergyCost = Energy 0,
+          stsType = TSTAccountTransaction (Just TTMetaUpdate),
+          stsResult = TxSuccess events,
+          stsIndex = TransactionIndex 0,
+          stsSponsorDetails = Nothing
+        }
+
+assertJsonRoundtrip :: String -> SupplementedTransactionSummary -> IO ()
+assertJsonRoundtrip name value =
+    case AE.fromJSON (AE.toJSON value) of
+        AE.Success decoded
+            | decoded == value -> pure ()
+            | otherwise -> fail $ name <> ": decoded value did not match original"
+        AE.Error err -> fail $ name <> ": failed to decode summary JSON: " <> err
+
+assertDecodeFixture :: FilePath -> IO ()
+assertDecodeFixture path = do
+    bytes <- LBS.readFile path
+    case AE.eitherDecode bytes :: Either String SupplementedTransactionSummary of
+        Right _ -> pure ()
+        Left err -> fail $ path <> ": failed to decode summary JSON: " <> err
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = do
+    assertJsonRoundtrip
+        "meta-update lock created summary"
+        ( summary
+            [ LockCreated
+                { elcLockId = lock 10,
+                  elcLockConfig = rawCborFromBytes "\161\100test\001"
+                }
+            ]
+        )
+    assertJsonRoundtrip
+        "meta-update lock destroyed summary"
+        (summary [LockDestroyed{eldLockId = lock 20}])
+    assertJsonRoundtrip
+        "meta-update token transfer with lock metadata summary"
+        ( summary
+            [ TokenTransfer
+                { ettTokenId = TokenId "CCD",
+                  ettFrom = HolderAccount (account 2),
+                  ettTo = HolderAccount (account 3),
+                  ettAmount = TokenAmount (TokenRawAmount 10) 0,
+                  ettMemo = Nothing,
+                  ettFromLock = Just (lock 30),
+                  ettToLock = Just (lock 40)
+                }
+            ]
+        )
+    assertDecodeFixture "test/fixtures/meta-update-lock-created.json"
+    assertDecodeFixture "test/fixtures/meta-update-lock-destroyed.json"
+    assertDecodeFixture "test/fixtures/meta-update-token-transfer-locks.json"

--- a/test/fixtures/meta-update-lock-created.json
+++ b/test/fixtures/meta-update-lock-created.json
@@ -1,0 +1,23 @@
+{
+  "sender": "2xBpaHottqhwFZURMZW4uZduQvpxNDSy46iXMYs9kceNGaPpZX",
+  "hash": "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+  "cost": "0",
+  "energyCost": 0,
+  "type": { "contents": "metaUpdate", "type": "accountTransaction" },
+  "result": {
+    "events": [
+      {
+        "lockConfig": "a1647465737401",
+        "lockId": {
+          "accountIndex": 10,
+          "creationOrder": 12,
+          "sequenceNumber": 11
+        },
+        "tag": "LockCreated"
+      }
+    ],
+    "outcome": "success"
+  },
+  "index": 0,
+  "sponsorDetails": null
+}

--- a/test/fixtures/meta-update-lock-destroyed.json
+++ b/test/fixtures/meta-update-lock-destroyed.json
@@ -1,0 +1,22 @@
+{
+  "sender": "2xBpaHottqhwFZURMZW4uZduQvpxNDSy46iXMYs9kceNGaPpZX",
+  "hash": "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+  "cost": "0",
+  "energyCost": 0,
+  "type": { "contents": "metaUpdate", "type": "accountTransaction" },
+  "result": {
+    "events": [
+      {
+        "lockId": {
+          "accountIndex": 20,
+          "creationOrder": 22,
+          "sequenceNumber": 21
+        },
+        "tag": "LockDestroyed"
+      }
+    ],
+    "outcome": "success"
+  },
+  "index": 0,
+  "sponsorDetails": null
+}

--- a/test/fixtures/meta-update-token-transfer-locks.json
+++ b/test/fixtures/meta-update-token-transfer-locks.json
@@ -1,0 +1,37 @@
+{
+  "sender": "2xBpaHottqhwFZURMZW4uZduQvpxNDSy46iXMYs9kceNGaPpZX",
+  "hash": "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+  "cost": "0",
+  "energyCost": 0,
+  "type": { "contents": "metaUpdate", "type": "accountTransaction" },
+  "result": {
+    "events": [
+      {
+        "amount": { "decimals": 0, "value": "10" },
+        "from": {
+          "address": "2xdTv8awN1BjgYEw8W1BVXVtiEwG2b29U8KoZQqJrDuEqddseE",
+          "type": "account"
+        },
+        "fromLock": {
+          "accountIndex": 30,
+          "creationOrder": 32,
+          "sequenceNumber": 31
+        },
+        "tag": "TokenTransfer",
+        "to": {
+          "address": "2y57FyMyqAfY7X1SuSWJ5VMt1Z3ZgxbKt9w5mGoTwqA7YcpbXr",
+          "type": "account"
+        },
+        "toLock": {
+          "accountIndex": 40,
+          "creationOrder": 42,
+          "sequenceNumber": 41
+        },
+        "tokenId": "CCD"
+      }
+    ],
+    "outcome": "success"
+  },
+  "index": 0,
+  "sponsorDetails": null
+}


### PR DESCRIPTION
Closes COR-2323
Depends on https://github.com/Concordium/concordium-client/pull/420.

## Purpose

Adds support for meta update transactions and lock operations. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.