### PR TITLE
feat: add proxy endpoint for block transaction events

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Add `GET` endpoint `/v0/blockTransactionEvents/{blockHash}` for getting the transaction events (outcomes) in a given block, proxying the node's `GetBlockTransactionEvents` method.
+
 ## [0.47.1] - 2026-03-17
 
 - Add `blockHeight` field to the response of `v0/accTransactions`, `v1/accTransactions`, `v2/accTransactions`, and `v3/accTransactions`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ cooldowns and the available balance) and get the info if an account is on any al
 * `GET /v0/consensusInfo`: get the current consensus status from the node.
 * `GET /v0/blockInfo/{blockHash}`: get block information for a given block hash.
 * `GET /v0/blocksAtHeight/{blockHeight}`: get the block hashes at a given absolute block height.
+* `GET /v0/blockTransactionEvents/{blockHash}`: get the transaction events (outcomes) in a given block.
 
 ### Errors
 
@@ -1623,6 +1624,45 @@ Example response:
 ```
 
 In rare cases of a branching chain, multiple hashes may be returned.
+
+## Block transaction events
+
+A GET request to `/v0/blockTransactionEvents/{blockHash}` returns the list of transaction events (transaction outcomes) contained in the block with the given hash. This proxies the node's `GetBlockTransactionEvents` method.
+
+Returns `404 Not Found` if no block with the given hash exists.
+
+Returns an empty list if the block contains no transactions.
+
+Each element is a transaction summary with the same shape as the summary returned by the `/v0/submissionStatus/{transactionHash}` endpoint, including fields such as `hash`, `sender`, `cost`, `energyCost`, `type`, `index`, and a `result` describing whether the transaction succeeded (with its events) or was rejected (with the reject reason).
+
+Example response:
+
+```json
+[
+  {
+    "hash": "7c0a... ",
+    "sender": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF",
+    "cost": "601",
+    "energyCost": 601,
+    "index": 0,
+    "type": {
+      "type": "accountTransaction",
+      "contents": "transfer"
+    },
+    "result": {
+      "outcome": "success",
+      "events": [
+        {
+          "tag": "Transferred",
+          "amount": "1000000",
+          "from": { "type": "AddressAccount", "address": "3uxeCZwa3SxbksPWHwXWxCsaPucZdzNaXsRbkztqUUYRo1MnvF" },
+          "to": { "type": "AddressAccount", "address": "4tjy... " }
+        }
+      ]
+    }
+  }
+]
+```
 
 # Deployment
 

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -327,6 +327,7 @@ mkYesod
 /v0/consensusInfo ConsensusInfoR GET
 /v0/blockInfo/#Text BlockInfoR GET
 /v0/blocksAtHeight/#Word64 BlocksAtHeightR GET
+/v0/blockTransactionEvents/#Text BlockTransactionEventsR GET
 |]
 
 instance Yesod Proxy where
@@ -3065,6 +3066,23 @@ getBlockInfoR hashText =
                 $ \blockInfo -> do
                     $(logOther "Trace") "Successfully got block info."
                     sendResponse $ toJSON blockInfo
+
+-- | Returns the transaction events (transaction outcomes) for the block with the given hash.
+--  This proxies the node's @GetBlockTransactionEvents@ method and returns the list of
+--  transaction summaries contained in the block.
+--  Returns 404 if no block with the given hash exists.
+--  If the block hash could not be parsed, a HTTP response with status code @400@ is returned.
+getBlockTransactionEventsR :: Text -> Handler TypedContent
+getBlockTransactionEventsR hashText =
+    case readMaybe (Text.unpack hashText) of
+        Nothing -> respond400Error EMMalformedBlockHash RequestInvalid
+        Just blockHash ->
+            runGRPCWithCustomError
+                (Just (StatusNotOkError NOT_FOUND, Just notFound404, Nothing, Just $ EMErrorResponse NotFound))
+                (getBlockTransactionEvents (Given blockHash))
+                $ \txEvents -> do
+                    $(logOther "Trace") "Successfully got block transaction events."
+                    sendResponse $ toJSON txEvents
 
 -- | Create a Transak on-ramp session. This requires an "address" parameter to be specified, which
 --  will be the address of the account to which the purchased funds will be sent.


### PR DESCRIPTION
## Purpose

This adds a proxy endpoint for the node's GRPC `getBlockTransactionEvents` method. This allows us to plug our block indexer without having to interface with both the node and wallet-proxy.

## Changes

- added proxy endpoint implementation
- updated doc/changelog

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
