### PR TITLE
Add x-api-key header to transak API calls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - Add `GET` endpoint `/v0/blockTransactionEvents/{blockHash}` for getting the transaction events (outcomes) in a given block, proxying the node's `GetBlockTransactionEvents` method.
+- Add the `x-api-key` header to outbound Transak API calls while preserving the existing request body `apiKey` fields.
 
 ## [0.47.1] - 2026-03-17
 

--- a/src/Transak.hs
+++ b/src/Transak.hs
@@ -98,7 +98,8 @@ refreshAccessToken TransakConfig{..} = do
     let requestURI = refreshTokenURI transakUseStaging
     initialRequest <- requestFromURI requestURI
     let requestObject = AE.object ["apiKey" AE..= transakApiKey]
-    let headers = ("api-secret", transakApiSecret) : jsonHeaders
+    -- Transak requires the partner API key to be sent in the x-api-key header on API calls.
+    let headers = ("api-secret", transakApiSecret) : ("x-api-key", encodeUtf8 transakApiKey) : jsonHeaders
     let request =
             initialRequest
                 { method = "POST",
@@ -174,7 +175,8 @@ createWidgetUrl TransakConfig{..} token addr = do
                           "disableWalletAddressForm" AE..= True
                         ]
                 ]
-    let headers = ("access-token", token) : jsonHeaders
+    -- Transak requires the partner API key to be sent in the x-api-key header on API calls.
+    let headers = ("access-token", token) : ("x-api-key", encodeUtf8 transakApiKey) : jsonHeaders
     let request =
             initialRequest
                 { method = "POST",


### PR DESCRIPTION
## Purpose

Ref [COR-2465](https://linear.app/concordium/issue/COR-2465/wallet-proxy-api-key-header-in-transak-requests)
