### PR TITLE
Add configurable Transak end-user IP sourcing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - Add `GET` endpoint `/v0/blockTransactionEvents/{blockHash}` for getting the transaction events (outcomes) in a given block, proxying the node's `GetBlockTransactionEvents` method.
 - Add the `x-api-key` header to outbound Transak API calls while preserving the existing request body `apiKey` fields.
+- Add configurable Transak end-user IP sourcing (`remote-address` or `x-forwarded-for`) and send the resolved value in the `x-user-ip` header on widget-session creation calls.
 
 ## [0.47.1] - 2026-03-17
 

--- a/README.md
+++ b/README.md
@@ -1477,6 +1477,8 @@ Example response:
 
 A POST request to `/v0/transakOnRamp?address={accountAddress}` returns a JSON object containing a URL
 that can be used to initiate the Transak on-ramp (for buying CCDs).
+This endpoint requires a Transak configuration file via `--transak-config`, including a configured
+source for the end-user IP address sent to Transak.
 
 Example request:
 
@@ -1720,7 +1722,7 @@ where
 - `--drop-account gtu-drop-account-0.json` keys of the gtu drop account
 - `--forced-update-config-v0 forced-update-config-v0.json` file with app update configuration for the old mobile wallet
 - `--forced-update-config-v1 forced-update-config-v1.json` file with app update configuration for the new mobile wallet
-- `--transak-config transak.json` JSON file with the configuration for the Transak on-ramp.
+- `--transak-config transak.json` JSON file with the configuration for the Transak on-ramp, including how to source the end-user IP address for Transak requests.
 - `--health-tolerance 30` tolerated age of last final block in seconds before the health query returns false
 - `--log-level debug` means all logs above debug will be printed. Options are
   `off`, `warning`, `error`, `info`, `debug`, `trace`.
@@ -1956,7 +1958,8 @@ format:
     "useStaging": false,
     "apiSecret": "MDEyMzQ1Njc4OWFiY2RlCg==",
     "apiKey": "3de320fb-5470-4608-88f1-647b513e64de",
-    "referrerDomain": "concordium.com"
+    "referrerDomain": "concordium.com",
+    "userIpSource": "x-forwarded-for"
 }
 ```
 where
@@ -1965,6 +1968,11 @@ where
 - `apiSecret` is the API secret provided by Transak.
 - `apiKey` is the API key provided by Transak.
 - `referrerDomain` is the domain registered with Transak for the project.
+- `userIpSource` is required and selects how the end-user IP is sourced for the `x-user-ip`
+  header on Transak widget-session requests. Supported values are:
+  - `remote-address`: use the remote IP address observed by wallet-proxy.
+  - `x-forwarded-for`: use the first comma-separated value from the `X-Forwarded-For` header,
+    after trimming whitespace.
 
 
 ## Release

--- a/package.yaml
+++ b/package.yaml
@@ -41,8 +41,10 @@ dependencies:
 - http2-grpc-types >= 0.5
 - microlens-platform
 - monad-logger >= 0.3.30
+- network
 - network-uri
 - persistent >= 2.9.2
+- wai
 - persistent-postgresql >= 2.9
 - random >= 1.1
 - range >= 0.3

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -47,8 +47,9 @@ import Data.Conduit.Attoparsec (sinkParserEither)
 import Data.Conduit.Binary (sinkLbs)
 import Data.Foldable
 import Data.Functor
+import Data.List (intercalate)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (catMaybes, fromMaybe, isJust, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, maybeToList)
 import qualified Data.Proxy as Proxy
 import Data.Range
 import qualified Data.Ratio as Rational
@@ -66,6 +67,9 @@ import qualified Database.Esqueleto.PostgreSQL.JSON as EJ
 import Lens.Micro.Platform hiding ((.=))
 import Network.GRPC.HTTP2.Types (GRPCStatusCode (..))
 import Network.HTTP.Types (Status, badGateway502, badRequest400, gatewayTimeout504, internalServerError500, notFound404, serviceUnavailable503)
+import Network.Socket (SockAddr (..), hostAddress6ToTuple, hostAddressToTuple)
+import qualified Network.Wai as Wai
+import Numeric (showHex)
 import Paths_wallet_proxy (version)
 import System.Random
 import Text.Read hiding (String)
@@ -3086,6 +3090,38 @@ getBlockTransactionEventsR hashText =
 
 -- | Create a Transak on-ramp session. This requires an "address" parameter to be specified, which
 --  will be the address of the account to which the purchased funds will be sent.
+resolveTransakUserIp :: Transak.TransakConfig -> Handler (Either Text Text)
+resolveTransakUserIp conf = do
+    req <- waiRequest
+    return $ case Transak.transakUserIpSource conf of
+        Transak.UserIpRemoteAddress ->
+            case renderRemoteHost (Wai.remoteHost req) of
+                Nothing -> Left "transakOnRamp: could not extract an IP address from the remote socket address"
+                Just ip -> Right ip
+        Transak.UserIpXForwardedFor ->
+            case lookup "x-forwarded-for" (Wai.requestHeaders req) of
+                Nothing -> Left "transakOnRamp: x-forwarded-for header is missing"
+                Just headerValue ->
+                    case Text.decodeUtf8' headerValue of
+                        Left err -> Left $ "transakOnRamp: x-forwarded-for header is not valid UTF-8: " <> Text.pack (show err)
+                        Right decoded ->
+                            case Text.strip <$> listToMaybe (Text.splitOn "," decoded) of
+                                Nothing -> Left "transakOnRamp: x-forwarded-for header does not contain a first IP address"
+                                Just firstIp ->
+                                    if Text.null firstIp
+                                        then Left "transakOnRamp: x-forwarded-for header does not contain a first IP address"
+                                        else Right firstIp
+  where
+    renderRemoteHost :: SockAddr -> Maybe Text
+    renderRemoteHost = \case
+        SockAddrInet _ hostAddress ->
+            let (a, b, c, d) = hostAddressToTuple hostAddress
+            in  Just . Text.pack $ show a ++ "." ++ show b ++ "." ++ show c ++ "." ++ show d
+        SockAddrInet6 _ _ hostAddress6 _ ->
+            let (g1, g2, g3, g4, g5, g6, g7, g8) = hostAddress6ToTuple hostAddress6
+            in  Just . Text.pack $ intercalate ":" (map (`showHex` "") [g1, g2, g3, g4, g5, g6, g7, g8])
+        _ -> Nothing
+
 postTransakOnRamp :: Handler TypedContent
 postTransakOnRamp = do
     yesod <- getYesod
@@ -3097,12 +3133,17 @@ postTransakOnRamp = do
                 Just addrText -> case addressFromText addrText of
                     Left _ -> respond400Error (EMParseError "'address' is not a valid account address") RequestInvalid
                     Right addr -> do
-                        res <- liftIO $ Transak.tryCreateWidgetUrl conf mvToken addr
-                        case res of
-                            Left (Transak.WUEBadGateway reason) -> do
-                                $(logError) ("transakOnRamp: " <> Text.pack reason)
-                                respondStatusError badGateway502 EMBadGateway InternalError
-                            Left Transak.WUEGatewayTimeout -> do
-                                $(logError) "transakOnRamp: gateway timeout"
-                                respondStatusError gatewayTimeout504 EMGatewayTimeout InternalError
-                            Right url -> sendResponse $ object ["widgetUrl" .= url]
+                        resolveTransakUserIp conf >>= \case
+                            Left reason -> do
+                                $(logError) reason
+                                respondStatusError internalServerError500 (EMErrorResponse $ Yesod.InternalError "Unable to determine the end-user IP for the Transak request.") InternalError
+                            Right userIp -> do
+                                res <- liftIO $ Transak.tryCreateWidgetUrl conf mvToken userIp addr
+                                case res of
+                                    Left (Transak.WUEBadGateway reason) -> do
+                                        $(logError) ("transakOnRamp: " <> Text.pack reason)
+                                        respondStatusError badGateway502 EMBadGateway InternalError
+                                    Left Transak.WUEGatewayTimeout -> do
+                                        $(logError) "transakOnRamp: gateway timeout"
+                                        respondStatusError gatewayTimeout504 EMGatewayTimeout InternalError
+                                    Right url -> sendResponse $ object ["widgetUrl" .= url]

--- a/src/Transak.hs
+++ b/src/Transak.hs
@@ -25,6 +25,12 @@ import Network.URI
 import Concordium.Types
 
 -- | Configuration for the Transak on-ramp.
+data UserIpSource
+    = UserIpRemoteAddress
+    | UserIpXForwardedFor
+    deriving (Eq, Show)
+
+-- | Configuration for the Transak on-ramp.
 data TransakConfig = TransakConfig
     { -- | Whether to use the staging environment.
       transakUseStaging :: !Bool,
@@ -33,8 +39,16 @@ data TransakConfig = TransakConfig
       -- | API key set by Transak.
       transakApiKey :: !Text,
       -- | Referrer domain to use with Transak calls.
-      transakReferrerDomain :: !Text
+      transakReferrerDomain :: !Text,
+      -- | Source for the end-user IP sent to Transak.
+      transakUserIpSource :: !UserIpSource
     }
+
+instance AE.FromJSON UserIpSource where
+    parseJSON = AE.withText "UserIpSource" $ \case
+        "remote-address" -> return UserIpRemoteAddress
+        "x-forwarded-for" -> return UserIpXForwardedFor
+        src -> fail $ "Invalid userIpSource: " ++ show src
 
 instance AE.FromJSON TransakConfig where
     parseJSON = AE.withObject "TransakConfig" $ \v -> do
@@ -42,6 +56,7 @@ instance AE.FromJSON TransakConfig where
         transakApiSecret <- encodeUtf8 <$> v AE..: "apiSecret"
         transakApiKey <- v AE..: "apiKey"
         transakReferrerDomain <- v AE..: "referrerDomain"
+        transakUserIpSource <- v AE..: "userIpSource"
         return TransakConfig{..}
 
 -- | Relative URI path for the refresh-token call.
@@ -158,10 +173,12 @@ createWidgetUrl ::
     TransakConfig ->
     -- | Access token
     BS.ByteString ->
+    -- | End-user IP address
+    Text ->
     -- | Account address to use
     AccountAddress ->
     IO (Either Status URI)
-createWidgetUrl TransakConfig{..} token addr = do
+createWidgetUrl TransakConfig{..} token userIp addr = do
     let requestURI = createWidgetUrlURI transakUseStaging
     initialRequest <- requestFromURI requestURI
     let requestObject =
@@ -175,8 +192,9 @@ createWidgetUrl TransakConfig{..} token addr = do
                           "disableWalletAddressForm" AE..= True
                         ]
                 ]
-    -- Transak requires the partner API key to be sent in the x-api-key header on API calls.
-    let headers = ("access-token", token) : ("x-api-key", encodeUtf8 transakApiKey) : jsonHeaders
+    -- Transak requires the partner API key on API calls and the originating end-user IP on
+    -- createWidgetUrl calls.
+    let headers = ("access-token", token) : ("x-api-key", encodeUtf8 transakApiKey) : ("x-user-ip", encodeUtf8 userIp) : jsonHeaders
     let request =
             initialRequest
                 { method = "POST",
@@ -213,8 +231,8 @@ data WidgetUrlError
 --  'WUEGatewayTimeout'.
 --  If an unexpected error occurred with the upstream server, including if the result could not be
 --  decoded, 'WUEBadGateway' is returned, with a description of the cause.
-tryCreateWidgetUrl :: TransakConfig -> MVar AccessToken -> AccountAddress -> IO (Either WidgetUrlError URI)
-tryCreateWidgetUrl conf mvToken addr = do
+tryCreateWidgetUrl :: TransakConfig -> MVar AccessToken -> Text -> AccountAddress -> IO (Either WidgetUrlError URI)
+tryCreateWidgetUrl conf mvToken userIp addr = do
     res <- race doIt (threadDelay 10000000)
     return $! case res of
         Left (Left err) -> Left $ WUEBadGateway err
@@ -224,13 +242,13 @@ tryCreateWidgetUrl conf mvToken addr = do
     doIt = do
         res <- try $ do
             token <- getAccessToken conf mvToken
-            createWidgetUrl conf (accessToken token) addr >>= \case
+            createWidgetUrl conf (accessToken token) userIp addr >>= \case
                 Left status
                     | status == status401 -> do
                         -- In the event of a 401, we retry in case another thread concurrently
                         -- refreshed the token, causing createWidgetUrl to fail.
                         token' <- getAccessToken conf mvToken
-                        createWidgetUrl conf (accessToken token') addr >>= \case
+                        createWidgetUrl conf (accessToken token') userIp addr >>= \case
                             Left e -> return (Left $ "(On retry) createWidgetUrl received status: " ++ show e)
                             Right uri -> return (Right uri)
                     | otherwise -> return (Left $ "createWidgetUrl received status: " ++ show status)


### PR DESCRIPTION
## Purpose
- Implement COR-2464 by forwarding the end-user IP to Transak on widget-session creation.
- Make the IP source explicit in Transak configuration for deployments that use either direct remote addresses or forwarded headers.
- Linear: https://linear.app/concordium/issue/COR-2464/wallet-proxy-user-ip-header-in-transak-apis

## Changes
- add required `userIpSource` to the Transak config with `remote-address` and `x-forwarded-for` options
- resolve the end-user IP in `/v0/transakOnRamp`, log extraction failures, and return 500 when the configured source cannot be used
- send `x-user-ip` on Transak `createWidgetUrl` requests only
- document the new Transak config field in the README and changelog