### PR TITLE
Add CORS protection for Transak endpoint

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 
+- Add application-level CORS handling. A new `--enable-public-cors` flag for the public API and a strict exact-origin allowlist for `POST /v0/transakOnRamp` configured via `allowedOrigins` in the Transak config file.
 - Add `GET` endpoint `/v0/blockTransactionEvents/{blockHash}` for getting the transaction events (outcomes) in a given block, proxying the node's `GetBlockTransactionEvents` method.
 - Add the `x-api-key` header to outbound Transak API calls while preserving the existing request body `apiKey` fields.
 - Add configurable Transak end-user IP sourcing (`remote-address` or `x-forwarded-for`) and send the resolved value in the `x-user-ip` header on widget-session creation calls.

--- a/README.md
+++ b/README.md
@@ -1493,9 +1493,11 @@ Example response:
 This endpoint can product 502 Bad Gateway or 504 Gateway Timeout responses if the up-stream server
 does not behave in the expected manner or times out.  (The proxy will time out after 10 seconds.)
 
+If the Transak endpoint is enabled, wallet-proxy applies application-level CORS protection to
+`/v0/transakOnRamp` and only emits `Access-Control-Allow-Origin` for origins listed in the
+Transak configuration file as [required by Transak](https://docs.transak.com/guides/mandatory-security-changes#cors-protection-on-apis).
+
 Note: per [Transak's documentation](https://docs.transak.com/reference/create-widget-url), the `widgetUrl` is valid only for 5 minutes from the time of creation.
-
-
 
 ## Genesis block hash
 
@@ -1692,6 +1694,7 @@ wallet-proxy --grpc-ip 127.0.0.1\
              --forced-update-config-v0 forced-update-config-v0.json\
              --forced-update-config-v1 forced-update-config-v1.json\
              --transak-config transak.json\
+             --enable-public-cors\
              --health-tolerance 30\
              --log-level debug\
              --grpc-timeout 15
@@ -1722,7 +1725,8 @@ where
 - `--drop-account gtu-drop-account-0.json` keys of the gtu drop account
 - `--forced-update-config-v0 forced-update-config-v0.json` file with app update configuration for the old mobile wallet
 - `--forced-update-config-v1 forced-update-config-v1.json` file with app update configuration for the new mobile wallet
-- `--transak-config transak.json` JSON file with the configuration for the Transak on-ramp, including how to source the end-user IP address for Transak requests.
+- `--transak-config transak.json` JSON file with the configuration for the Transak on-ramp, including how to source the end-user IP address for Transak requests and which browser origins may access the endpoint.
+- `--enable-public-cors` enables application-level wildcard CORS handling for the public wallet-proxy endpoints. The `/v0/transakOnRamp` endpoint always uses the stricter Transak-specific origin allowlist instead.
 - `--health-tolerance 30` tolerated age of last final block in seconds before the health query returns false
 - `--log-level debug` means all logs above debug will be printed. Options are
   `off`, `warning`, `error`, `info`, `debug`, `trace`.
@@ -1959,7 +1963,11 @@ format:
     "apiSecret": "MDEyMzQ1Njc4OWFiY2RlCg==",
     "apiKey": "3de320fb-5470-4608-88f1-647b513e64de",
     "referrerDomain": "concordium.com",
-    "userIpSource": "x-forwarded-for"
+    "userIpSource": "x-forwarded-for",
+    "allowedOrigins": [
+        "chrome-extension://abcdefghijklmnopqrstuvwxyzabcdef",
+        "https://wallet.concordium.com"
+    ]
 }
 ```
 where
@@ -1973,6 +1981,9 @@ where
   - `remote-address`: use the remote IP address observed by wallet-proxy.
   - `x-forwarded-for`: use the first comma-separated value from the `X-Forwarded-For` header,
     after trimming whitespace.
+- `allowedOrigins` is required and must contain one or more exact browser origins that may access
+  `/v0/transakOnRamp`. When the request `Origin` matches one of these values, wallet-proxy echoes
+  it in the `Access-Control-Allow-Origin` response header. Wildcards are not supported.
 
 
 ## Release

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,13 +8,19 @@ module Main where
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.CaseInsensitive as CI
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.String
 import Database.Persist.Postgresql
 import qualified Logging
+import Network.HTTP.Types.Method (methodGet, methodOptions, methodPost, methodPut)
+import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp
+import Network.Wai.Middleware.Cors
 import Proxy
 import Yesod
 
@@ -56,7 +62,8 @@ data ProxyConfig = ProxyConfig
       logLevel :: Logging.LogLevel,
       tcVersion :: Maybe String,
       tcUrl :: Maybe String,
-      transakConfig :: Maybe FilePath
+      transakConfig :: Maybe FilePath,
+      pcEnablePublicCors :: Bool
     }
 
 parser :: ParserInfo ProxyConfig
@@ -83,6 +90,7 @@ parser =
             <*> optional (strOption (long "tc-version" <> metavar "STRING" <> help "Version of terms and conditions in effect."))
             <*> optional (strOption (long "tc-url" <> metavar "URL" <> help "Link to the terms and conditions."))
             <*> optional (strOption (long "transak-config" <> metavar "FILE" <> help "File with configuration for Transak on-ramp gateway."))
+            <*> switch (long "enable-public-cors" <> help "Enable wildcard CORS handling for public wallet-proxy endpoints.")
 
     mkProxyConfig backend timeout =
         ProxyConfig $
@@ -94,8 +102,8 @@ parser =
                 (Just (fromMaybe 15 timeout))
                 (CMDS.grpcUseTls backend)
 
-runSite :: (YesodDispatch site) => Int -> site -> IO ()
-runSite port site = do
+runSite :: (YesodDispatch site) => Int -> Wai.Middleware -> site -> IO ()
+runSite port middleware site = do
     toWaiApp site
         >>= Network.Wai.Handler.Warp.runSettings
             ( Network.Wai.Handler.Warp.setPort port $
@@ -103,6 +111,41 @@ runSite port site = do
                     Network.Wai.Handler.Warp.setHost (fromString serverHost) $
                         Network.Wai.Handler.Warp.defaultSettings
             )
+            . middleware
+
+transakOnRampPath :: ByteString
+transakOnRampPath = "/v0/transakOnRamp"
+
+mkCorsMiddleware :: Bool -> Maybe Transak.TransakConfig -> Wai.Middleware
+mkCorsMiddleware enablePublicCors mTransakConf =
+    cors $ \req ->
+        case Wai.rawPathInfo req of
+            path
+                | path == transakOnRampPath -> transakCorsPolicy <$> mTransakConf
+                | enablePublicCors -> Just (publicCorsPolicy req)
+                | otherwise -> Nothing
+  where
+    transakCorsPolicy conf =
+        simpleCorsResourcePolicy
+            { corsOrigins = Just (NonEmpty.toList (Transak.transakAllowedOrigins conf), False),
+              corsMethods = [methodPost, methodOptions],
+              corsRequestHeaders = ["Content-Type"],
+              corsVaryOrigin = True,
+              corsRequireOrigin = False,
+              corsIgnoreFailures = True
+            }
+    publicCorsPolicy req =
+        simpleCorsResourcePolicy
+            { corsOrigins = Nothing,
+              corsMethods = [methodGet, methodPost, methodPut, methodOptions],
+              corsRequestHeaders = requestedHeaders req,
+              corsRequireOrigin = False,
+              corsIgnoreFailures = True
+            }
+    requestedHeaders =
+        maybe [] (map (CI.mk . BS8.strip) . BS8.split ',')
+            . lookup "Access-Control-Request-Headers"
+            . Wai.requestHeaders
 
 accountParser :: AE.Value -> AE.Parser (AccountAddress, [(CredentialIndex, [(KeyIndex, KeyPair)])])
 accountParser = AE.withObject "Account keys" $ \v -> do
@@ -205,5 +248,6 @@ main = do
                     Right res -> case getResponseValue res of
                         Right cParams -> do
                             let globalInfo = toJSON $ Versioned (Version 0) cParams
-                            runSite pcPort Proxy{grpcEnvData = cfg, ..}
+                            let corsMiddleware = mkCorsMiddleware pcEnablePublicCors (fst <$> transakState)
+                            runSite pcPort corsMiddleware Proxy{grpcEnvData = cfg, ..}
                         Left (_, err) -> die $ "Cannot obtain cryptographic parameters due to error: " ++ err

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,6 +23,7 @@ grpc_retry="${GRPC_RETRY:-0}" # number of times to retry a failed request
 tc_version="${TC_VERSION-}"
 tc_url="${TC_URL-}"
 transak_config_file="${TRANSAK_CONFIG_FILE-}"
+enable_public_cors="${ENABLE_PUBLIC_CORS:-false}"
 
 args=(
 	--grpc-ip "${grpc_host}"
@@ -58,6 +59,9 @@ if [ "${use_tls}" = "true" ]; then
 fi
 if [ -n "${transak_config_file}" ]; then
 	args+=( --transak-config "${transak_config_file}" )
+fi
+if [ "${enable_public_cors}" = "true" ]; then
+	args+=( --enable-public-cors )
 fi
 
 # Inherits env vars and args.

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - base >=4.7 && < 5
 - base16-bytestring >= 0.1.1.6
 - bytestring >= 0.10
+- case-insensitive
 - cereal >= 0.5.7
 - concordium-base
 - concordium-client
@@ -45,6 +46,7 @@ dependencies:
 - network-uri
 - persistent >= 2.9.2
 - wai
+- wai-cors
 - persistent-postgresql >= 2.9
 - random >= 1.1
 - range >= 0.3

--- a/src/Proxy.hs
+++ b/src/Proxy.hs
@@ -66,7 +66,7 @@ import qualified Database.Esqueleto.Legacy as E
 import qualified Database.Esqueleto.PostgreSQL.JSON as EJ
 import Lens.Micro.Platform hiding ((.=))
 import Network.GRPC.HTTP2.Types (GRPCStatusCode (..))
-import Network.HTTP.Types (Status, badGateway502, badRequest400, gatewayTimeout504, internalServerError500, notFound404, serviceUnavailable503)
+import Network.HTTP.Types (Status, badGateway502, badRequest400, gatewayTimeout504, internalServerError500, notFound404, serviceUnavailable503, status200)
 import Network.Socket (SockAddr (..), hostAddress6ToTuple, hostAddressToTuple)
 import qualified Network.Wai as Wai
 import Numeric (showHex)
@@ -326,7 +326,7 @@ mkYesod
 /v0/plt/tokens PltTokensR GET
 /v0/plt/tokenInfo/#Text PltTokenInfoR GET
 /v0/keyAccounts/#Text KeyAccounts GET
-/v0/transakOnRamp TransakOnRamp POST
+/v0/transakOnRamp TransakOnRamp POST OPTIONS
 /v0/genesisHash GenesisHash GET
 /v0/consensusInfo ConsensusInfoR GET
 /v0/blockInfo/#Text BlockInfoR GET
@@ -3121,6 +3121,13 @@ resolveTransakUserIp conf = do
             let (g1, g2, g3, g4, g5, g6, g7, g8) = hostAddress6ToTuple hostAddress6
             in  Just . Text.pack $ intercalate ":" (map (`showHex` "") [g1, g2, g3, g4, g5, g6, g7, g8])
         _ -> Nothing
+
+optionsTransakOnRamp :: Handler TypedContent
+optionsTransakOnRamp = do
+    yesod <- getYesod
+    case transakState yesod of
+        Nothing -> respond404Error (EMErrorResponse NotFound)
+        Just _ -> sendResponseStatus status200 ("" :: Text)
 
 postTransakOnRamp :: Handler TypedContent
 postTransakOnRamp = do

--- a/src/Transak.hs
+++ b/src/Transak.hs
@@ -13,6 +13,8 @@ import Control.Exception
 import Control.Monad
 import qualified Data.Aeson as AE
 import qualified Data.ByteString as BS
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
@@ -41,7 +43,9 @@ data TransakConfig = TransakConfig
       -- | Referrer domain to use with Transak calls.
       transakReferrerDomain :: !Text,
       -- | Source for the end-user IP sent to Transak.
-      transakUserIpSource :: !UserIpSource
+      transakUserIpSource :: !UserIpSource,
+      -- | Browser origins allowed to access the wallet-proxy Transak endpoint.
+      transakAllowedOrigins :: !(NonEmpty BS.ByteString)
     }
 
 instance AE.FromJSON UserIpSource where
@@ -57,6 +61,11 @@ instance AE.FromJSON TransakConfig where
         transakApiKey <- v AE..: "apiKey"
         transakReferrerDomain <- v AE..: "referrerDomain"
         transakUserIpSource <- v AE..: "userIpSource"
+        allowedOrigins <- v AE..: "allowedOrigins"
+        transakAllowedOrigins <-
+            case NonEmpty.nonEmpty (map encodeUtf8 allowedOrigins) of
+                Nothing -> fail "allowedOrigins must contain at least one origin"
+                Just origins -> return origins
         return TransakConfig{..}
 
 -- | Relative URI path for the refresh-token call.


### PR DESCRIPTION
## Purpose
- Implement COR-2463: https://linear.app/concordium/issue/COR-2463/wallet-proxy-add-cors-protection-on-transak-endpoint
- Move CORS handling for wallet-proxy into the application so the Transak endpoint can use a stricter origin policy without duplicate infrastructure headers.

## Changes
- add `wai-cors` middleware and a new `--enable-public-cors` flag for wildcard CORS on the public API
- add strict exact-origin CORS handling and `OPTIONS` support for `/v0/transakOnRamp`
- extend the Transak config with required `allowedOrigins` and wire the Docker entrypoint to the new public CORS flag
- update README and changelog for the new CORS configuration